### PR TITLE
Feature/incorporate sensors into rocket

### DIFF
--- a/lib/Vector3/Vector3.cpp
+++ b/lib/Vector3/Vector3.cpp
@@ -100,3 +100,10 @@ Vector3 Vector3::normalized() {
 		return Vector3();
 	}
 }
+
+void Vector3::randomize(std::default_random_engine& generator,
+						std::normal_distribution<double>& dist) {
+		x = dist(generator);
+		y = dist(generator);
+		z = dist(generator);
+}

--- a/lib/Vector3/Vector3.h
+++ b/lib/Vector3/Vector3.h
@@ -2,6 +2,7 @@
 #ifndef _VECTOR3_H_
 #define _VECTOR3_H_
 
+#include <random>
 
 class Vector3 {
 public:
@@ -31,6 +32,9 @@ public:
 	double magnitude2() const;
 	void normalize();
 	Vector3 normalized();
+
+	void randomize(std::default_random_engine& generator,
+				   std::normal_distribution<double>& dist);
 
 };
 

--- a/sim_data/plotter.py
+++ b/sim_data/plotter.py
@@ -14,7 +14,7 @@ vx = []
 vy = []
 vz = []
 
-ax = []
+aX = []
 ay = []
 az = []
 
@@ -35,8 +35,13 @@ rocketX = []
 rocketY = []
 rocketZ = []
 
-data_lists = [timestamps, rx, ry, rz, vx, vy, vz, ax, ay, az, fx, fy, fz,
-              q0, q1, q2, q3, roll, pitch, yaw, rocketX, rocketY, rocketZ]
+sensorX = []
+sensorY = []
+sensorZ = []
+
+data_lists = [timestamps, rx, ry, rz, vx, vy, vz, aX, ay, az, fx, fy, fz,
+              q0, q1, q2, q3, roll, pitch, yaw, rocketX, rocketY, rocketZ,
+              sensorX, sensorY, sensorZ]
 
 with open("sim_data/data.csv") as csvfile:
     csvreader = csv.reader(csvfile, delimiter=",")
@@ -92,5 +97,22 @@ ax = fig.add_subplot(339)
 ax.plot(timestamps, yaw, 'b', label="Yaw")
 ax.grid()
 ax.legend()
+
+fig = plt.figure()
+ax = fig.add_subplot(311)
+plt.plot(timestamps, aX, color='r', linewidth=2.0, label="X Accel Truth")
+plt.plot(timestamps, sensorX, color='g', label="X Accel Sensor Output")
+plt.grid()
+plt.legend()
+ax = fig.add_subplot(312)
+plt.plot(timestamps, ay, color='r', linewidth=2.0, label="Y Accel Truth")
+plt.plot(timestamps, sensorY, color='g', label="Y Accel Sensor Output")
+plt.grid()
+plt.legend()
+ax = fig.add_subplot(313)
+plt.plot(timestamps, az, color='r', linewidth=2.0, label="Z Accel Truth")
+plt.plot(timestamps, sensorZ, color='g', label="Z Accel Sensor Output")
+plt.grid()
+plt.legend()
 
 plt.show()

--- a/src/Rocket.cpp
+++ b/src/Rocket.cpp
@@ -16,7 +16,6 @@
 #include <iostream>
 
 #include "Rocket.h"
-#include "Sensor.h"
 #include "quaternion.h"
 #include "Vector3.h"
 
@@ -128,3 +127,4 @@ Vector3 Rocket::r2i(Vector3 vector) {
 	newVector.z = p.Getz();
 	return newVector;
 }
+

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -9,7 +9,7 @@
  * the flight software being tested can obtain information of the simulated rocket.
  * The classes provide a modular a means of injecting noise and bias along with
  * other inaccuracies to make sensor measurements behave closer to real hardware
- * rather than simply providing gorund truth. 
+ * rather than simply providing ground truth. 
  *
  */
 

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -19,8 +19,9 @@
 #include "Rocket.h"
 #include "Sensor.h"
 
-Gyroscope::Gyroscope(std::string name, Rocket& rocket, double refresh_rate) :
-								Sensor(name, rocket, refresh_rate) {
+Gyroscope::Gyroscope(std::string name, Rocket& rocket, double refresh_rate,
+				     double noise_mean, double noise_stddev) :
+	Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
 	_data = Vector3();
 }
 
@@ -29,6 +30,15 @@ void Gyroscope::update_data(double tStep) {
 		_rocket.get_w_vect(_data);
 		_rocket.i2r(_data);
 		_new_data = true;
+
+		if (_inject_noise) {
+			_noise.randomize(_generator, _normal_dist);
+			_data += _noise;
+		}
+
+		if (_inject_bias) {
+			_data += _bias;
+		}
 	}
 }
 
@@ -37,8 +47,9 @@ void Gyroscope::get_data(Vector3& data) {
 	_new_data = false;
 }
 
-Accelerometer::Accelerometer(std::string name, Rocket& rocket, double refresh_rate) :
-								Sensor(name, rocket, refresh_rate) {
+Accelerometer::Accelerometer(std::string name, Rocket& rocket, double refresh_rate,
+							 double noise_mean, double noise_stddev) :
+	Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
 	_data = Vector3();
 }
 
@@ -47,6 +58,15 @@ void Accelerometer::update_data(double tStep) {
 		_rocket.get_r_ddot(_data);
 		_rocket.i2r(_data);
 		_new_data = true;
+
+		if (_inject_noise) {
+			_noise.randomize(_generator, _normal_dist);
+			_data += _noise;
+		}
+
+		if (_inject_bias) {
+			_data += _bias;
+		}
 	}
 }
 
@@ -55,10 +75,25 @@ void Accelerometer::get_data(Vector3& data) {
 	_new_data = false;
 }
 
+Barometer::Barometer(std::string name, Rocket& rocket, double refresh_rate,
+					 double noise_mean, double noise_stddev) :
+	Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
+	_data = _rocket.get_r_vect().x;	
+}
+
 void Barometer::update_data(double tStep) {
 	if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
 		_data = _rocket.get_r_vect().x;
 		_new_data = true;
+
+		if (_inject_noise) {
+			_noise = _normal_dist(_generator);
+			_data += _noise;
+		}
+
+		if (_inject_bias) {
+			_data += _bias;
+		}
 	}
 }
 

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -9,7 +9,7 @@
  * the flight software being tested can obtain information of the simulated rocket.
  * The classes provide a modular a means of injecting noise and bias along with
  * other inaccuracies to make sensor measurements behave closer to real hardware
- * rather than simply proving gorund truth. 
+ * rather than simply providing gorund truth. 
  *
  */
 
@@ -19,8 +19,8 @@
 #include "Rocket.h"
 #include "Sensor.h"
 
-Gyroscope::Gyroscope(Rocket& rocket, double refresh_rate) :
-								Sensor(rocket, refresh_rate) {
+Gyroscope::Gyroscope(std::string name, Rocket& rocket, double refresh_rate) :
+								Sensor(name, rocket, refresh_rate) {
 	_data = Vector3();
 }
 
@@ -37,8 +37,8 @@ void Gyroscope::get_data(Vector3& data) {
 	_new_data = false;
 }
 
-Accelerometer::Accelerometer(Rocket& rocket, double refresh_rate) :
-								Sensor(rocket, refresh_rate) {
+Accelerometer::Accelerometer(std::string name, Rocket& rocket, double refresh_rate) :
+								Sensor(name, rocket, refresh_rate) {
 	_data = Vector3();
 }
 
@@ -57,13 +57,12 @@ void Accelerometer::get_data(Vector3& data) {
 
 void Barometer::update_data(double tStep) {
 	if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
-		_rocket.get_r_vect(_data);
-		_data_scalar = _data.x;
+		_data = _rocket.get_r_vect().x;
 		_new_data = true;
 	}
 }
 
 void Barometer::get_data(double& data) {
-	data = _data_scalar;
+	data = _data;
 	_new_data = false;
 }

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -2,14 +2,14 @@
  * @file 		Sensor.h	
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		Class definition for sensor components
+ * @brief 		Class definition for Sensor classes 
  *
  * These Sensor classes encapsulate typical sensors found on Rocket avionics 
  * like accelerometers and gyroscopes. This is the mechanism through which 
  * the flight software being tested can obtain information of the simulated rocket.
  * The classes provide a modular a means of injecting noise and bias along with
  * other inaccuracies to make sensor measurements behave closer to real hardware
- * rather than simply proving gorund truth. 
+ * rather than simply providing gorund truth. 
  *
  */
 
@@ -25,47 +25,84 @@
 #include "Vector3.h"
 
 class Sensor {
-public:
-	Sensor(Rocket& rocket, double refresh_rate) : 	_rocket(rocket),
-													_refresh_rate(refresh_rate),
-													_last_update_tStep(0),
-													_data_scalar(0) {};
+	public:
+		Sensor(std::string name, Rocket& rocket, double refresh_rate) :
+														_name(name),
+														_rocket(rocket),
+														_refresh_rate(refresh_rate),
+														_last_update_tStep(0) {};
 
-	bool is_new_data() {return _new_data;};
+		bool is_new_data() {return _new_data;};
 
-	virtual void update_data(double tStep) = 0;
-	virtual void get_data(Vector3& data) = 0;
+		virtual void update_data(double tStep) = 0;
+		virtual void get_data(Vector3& data) = 0;
+		// virtual void get_data(double& data) = 0;
 
-protected:
-	Rocket& _rocket;
+	protected:
 
-	double _refresh_rate;
-	double _last_update_tStep;
-	bool _new_data;
+		std::string _name;
+		
+		Rocket& _rocket;
 
-	Vector3 _data;
-	double _data_scalar;
+		double _refresh_rate;
+		double _last_update_tStep;
+		bool _new_data;
+
 };
 
 class Gyroscope : public Sensor {
-public:
-	Gyroscope(Rocket& rocket, double refresh_rate);
-	void update_data(double tStep);
-	void get_data(Vector3& data);
+	public:
+		Gyroscope(std::string name, Rocket& rocket, double refresh_rate);
+		void update_data(double tStep);
+		void get_data(Vector3& data);
+
+	private:
+		Vector3 _data; // The sensor's current reading
+
+		bool _inject_noise; 		// Whether to inject random noise to measurement
+		double _noise_magnitude; 	// Maximum magnitude of the noise
+		double _noise_std_dev; 		// Standard deviation of the noise
+		Vector3 _noise; 			// Noise vector to be added to measurement
+
+		bool _inject_bias; 	// Whether to inject constant bias to measurement
+		Vector3 _bias; 		// Constant bias vector to be added to measurement	
 };
 
 class Accelerometer : public Sensor {
-public:
-	Accelerometer(Rocket& rocket, double refresh_rate);
-	void update_data(double tStep);
-	void get_data(Vector3& data);
+	public:
+		Accelerometer(std::string name, Rocket& rocket, double refresh_rate);
+		void update_data(double tStep);
+		void get_data(Vector3& data);
+
+ 	private:
+		Vector3 _data; // The sensor's current reading
+
+		bool _inject_noise; 		// Whether to inject random noise to measurement
+		double _noise_magnitude; 	// Maximum magnitude of the noise
+		double _noise_std_dev; 		// Standard deviation of the noise
+		Vector3 _noise; 			// Noise vector to be added to measurement
+
+		bool _inject_bias; 	// Whether to inject constant bias to measurement
+		Vector3 _bias; 		// Constant bias vector to be added to measurement	
 };
 
+// TODO: Implement functions for both altitude and pressure measurements (and specify units)
 class Barometer : public Sensor {
-public:
-	Barometer(Rocket& rocket, double refresh_rate);
-	void update_data(double tStep);
-	void get_data(double& data);
+	public:
+		Barometer(std::string name, Rocket& rocket, double refresh_rate);
+		void update_data(double tStep);
+		void get_data(double& data);
+	
+	private:
+		double _data; 	// The sensor's current reading
+
+		bool _inject_noise; 		// Whether to inject random noise to measurement
+		double _noise_magnitude; 	// Maximum magnitude of the noise
+		double _noise_std_dev; 		// Standard deviation of the noise
+		double _noise; 				// Noise value to be added to measurement
+
+		bool _inject_bias; 	// Whether to inject constant bias to measurement
+		double _bias; 		// Constant bias value to be added to measurement	
 };
 
 #endif

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -28,7 +28,7 @@
 class Sensor {
 	public:
 		Sensor(std::string name, Rocket& rocket, double refresh_rate,
-			   double noise_mean=0.0f, double noise_stddev=1.0f) :
+			   double noise_mean=0.0f, double noise_stddev=0.1f) :
 														_name(name),
 														_rocket(rocket),
 														_refresh_rate(refresh_rate),
@@ -36,6 +36,7 @@ class Sensor {
 														_normal_dist(noise_mean, noise_stddev) {};
 
 		bool is_new_data() {return _new_data;};
+		std::string get_name() {return _name;};
 
 		virtual void update_data(double tStep) = 0;
 		virtual void get_data(Vector3& data) = 0;
@@ -67,7 +68,7 @@ class Sensor {
 class Gyroscope : public Sensor {
 	public:
 		Gyroscope(std::string name, Rocket& rocket, double refresh_rate,
-				  double noise_mean=0.0f, double noise_stddev=1.0f);
+				  double noise_mean=0.0f, double noise_stddev=0.1f);
 		void update_data(double tStep);
 		void get_data(Vector3& data);
 
@@ -84,16 +85,16 @@ class Gyroscope : public Sensor {
 class Accelerometer : public Sensor {
 	public:
 		Accelerometer(std::string name, Rocket& rocket, double refresh_rate,
-					  double noise_mean=0.0f, double noise_stddev=1.0f);
+					  double noise_mean=0.0f, double noise_stddev=0.1f);
 		void update_data(double tStep);
 		void get_data(Vector3& data);
 
 		void set_constant_bias(Vector3 bias) {_bias = bias;};
 
  	private:
-		Vector3 _data; // The sensor's current reading
+		Vector3 _data; 		// The sensor's current reading
 
-		Vector3 _noise; 			// Noise vector to be added to measurement
+		Vector3 _noise; 	// Noise vector to be added to measurement
 
 		Vector3 _bias; 		// Constant bias vector to be added to measurement	
 };
@@ -102,16 +103,16 @@ class Accelerometer : public Sensor {
 class Barometer : public Sensor {
 	public:
 		Barometer(std::string name, Rocket& rocket, double refresh_rate,
-				  double noise_mean=0.0f, double noise_stddev=1.0f);
+				  double noise_mean=0.0f, double noise_stddev=0.1f);
 		void update_data(double tStep);
 		void get_data(double& data);
 
 		void set_constant_bias(double bias) {_bias = bias;};
 	
 	private:
-		double _data; 	// The sensor's current reading
+		double _data; 		// The sensor's current reading
 
-		double _noise; 				// Noise value to be added to measurement
+		double _noise; 		// Noise value to be added to measurement
 
 		double _bias; 		// Constant bias value to be added to measurement	
 };

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -20,23 +20,32 @@
 
 #include <string>
 #include <vector>
+#include <random>
 
 #include "Rocket.h"
 #include "Vector3.h"
 
 class Sensor {
 	public:
-		Sensor(std::string name, Rocket& rocket, double refresh_rate) :
+		Sensor(std::string name, Rocket& rocket, double refresh_rate,
+			   double noise_mean=0.0f, double noise_stddev=1.0f) :
 														_name(name),
 														_rocket(rocket),
 														_refresh_rate(refresh_rate),
-														_last_update_tStep(0) {};
+														_last_update_tStep(0),
+														_normal_dist(noise_mean, noise_stddev) {};
 
 		bool is_new_data() {return _new_data;};
 
 		virtual void update_data(double tStep) = 0;
 		virtual void get_data(Vector3& data) = 0;
 		// virtual void get_data(double& data) = 0;
+
+		// Noise/bias injection control
+		void enable_noise_injection() 	{_inject_noise = true;};
+		void disable_noise_injection() 	{_inject_noise = false;};
+		void enable_bias_injection() 	{_inject_bias = true;};
+		void disable_bias_injection() 	{_inject_bias = false;};
 
 	protected:
 
@@ -48,60 +57,62 @@ class Sensor {
 		double _last_update_tStep;
 		bool _new_data;
 
+		// Normal distribution noise generation
+		std::default_random_engine _generator;
+		std::normal_distribution<double> _normal_dist;
+		bool _inject_bias = false; 			// Whether to inject constant bias to measurement
+		bool _inject_noise = false; 		// Whether to inject random noise to measurement
 };
 
 class Gyroscope : public Sensor {
 	public:
-		Gyroscope(std::string name, Rocket& rocket, double refresh_rate);
+		Gyroscope(std::string name, Rocket& rocket, double refresh_rate,
+				  double noise_mean=0.0f, double noise_stddev=1.0f);
 		void update_data(double tStep);
 		void get_data(Vector3& data);
 
+		void set_constant_bias(Vector3 bias) {_bias = bias;};
+
 	private:
-		Vector3 _data; // The sensor's current reading
+		Vector3 _data; 		// The sensor's current reading
 
-		bool _inject_noise; 		// Whether to inject random noise to measurement
-		double _noise_magnitude; 	// Maximum magnitude of the noise
-		double _noise_std_dev; 		// Standard deviation of the noise
-		Vector3 _noise; 			// Noise vector to be added to measurement
-
-		bool _inject_bias; 	// Whether to inject constant bias to measurement
+		Vector3 _noise; 	// Noise vector to be added to measurement
+				
 		Vector3 _bias; 		// Constant bias vector to be added to measurement	
 };
 
 class Accelerometer : public Sensor {
 	public:
-		Accelerometer(std::string name, Rocket& rocket, double refresh_rate);
+		Accelerometer(std::string name, Rocket& rocket, double refresh_rate,
+					  double noise_mean=0.0f, double noise_stddev=1.0f);
 		void update_data(double tStep);
 		void get_data(Vector3& data);
+
+		void set_constant_bias(Vector3 bias) {_bias = bias;};
 
  	private:
 		Vector3 _data; // The sensor's current reading
 
-		bool _inject_noise; 		// Whether to inject random noise to measurement
-		double _noise_magnitude; 	// Maximum magnitude of the noise
-		double _noise_std_dev; 		// Standard deviation of the noise
 		Vector3 _noise; 			// Noise vector to be added to measurement
 
-		bool _inject_bias; 	// Whether to inject constant bias to measurement
 		Vector3 _bias; 		// Constant bias vector to be added to measurement	
 };
 
 // TODO: Implement functions for both altitude and pressure measurements (and specify units)
 class Barometer : public Sensor {
 	public:
-		Barometer(std::string name, Rocket& rocket, double refresh_rate);
+		Barometer(std::string name, Rocket& rocket, double refresh_rate,
+				  double noise_mean=0.0f, double noise_stddev=1.0f);
 		void update_data(double tStep);
 		void get_data(double& data);
+
+		void set_constant_bias(double bias) {_bias = bias;};
 	
 	private:
 		double _data; 	// The sensor's current reading
 
-		bool _inject_noise; 		// Whether to inject random noise to measurement
-		double _noise_magnitude; 	// Maximum magnitude of the noise
-		double _noise_std_dev; 		// Standard deviation of the noise
 		double _noise; 				// Noise value to be added to measurement
 
-		bool _inject_bias; 	// Whether to inject constant bias to measurement
 		double _bias; 		// Constant bias value to be added to measurement	
 };
 

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -9,7 +9,7 @@
  * the flight software being tested can obtain information of the simulated rocket.
  * The classes provide a modular a means of injecting noise and bias along with
  * other inaccuracies to make sensor measurements behave closer to real hardware
- * rather than simply providing gorund truth. 
+ * rather than simply providing ground truth. 
  *
  */
 

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -83,6 +83,8 @@ void Simulation::run(int steps) {
 
 		_engine.march_step(_tStamp, _tStep);
 
+		update_sensors();
+
 		dataFile << _tStamp << ",";
 		dataFile << r_vect.x << "," << r_vect.y << "," << r_vect.z << ",";
 		dataFile << r_dot.x << "," << r_dot.y << "," << r_dot.z << ",";
@@ -90,7 +92,13 @@ void Simulation::run(int steps) {
 		dataFile << f_net.x << "," << f_net.y << "," << f_net.z << ",";
 		dataFile << s << "," << x << "," << y << "," << z  << ",";
 		dataFile << roll << "," << pitch << "," << yaw << ",";
-		dataFile << rocket_axis.x << "," << rocket_axis.y << "," << rocket_axis.z << "\n";
+		dataFile << rocket_axis.x << "," << rocket_axis.y << "," << rocket_axis.z << ",";
+		
+		Vector3 sensor_data;
+		_sensors[0]->get_data(sensor_data);
+		dataFile << sensor_data.x << "," << sensor_data.y << "," << sensor_data.z;
+
+		dataFile << "\n";
 
 		_tStamp += _tStep;
 

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -101,3 +101,23 @@ void Simulation::run(int steps) {
 
 	dataFile.close();
 }
+
+/**
+ * @brief Adds a new sensor on the rocket to the simulation 
+ *
+ * @param sensor A pointer to the new Sensor object to be added
+ */
+void Simulation::add_sensor(Sensor* sensor) {
+		_sensors.push_back(sensor);
+}
+
+/**
+ * @brief Updates all sensors' internal data 
+ *
+ */
+void Simulation::update_sensors() {
+		for (std::vector<Sensor*>::iterator it = _sensors.begin(); it != _sensors.end(); ++it) {
+				(*it)->update_data(_tStamp);
+		}
+
+}

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -43,6 +43,10 @@ public:
 
 	void run(int steps);
 
+	/************************* Sensor interface ***************************/
+	void add_sensor(Sensor* sensor);
+	void update_sensors();
+
 
 private:
 	double _tStamp;
@@ -52,7 +56,9 @@ private:
 
 	Rocket& _rocket;
 	SolidMotor& _motor;
-	// std::vector<Sensor&>& _sensors;
+	
+	// Sensors
+	std::vector<Sensor*> _sensors; 	// array of sensors on the rocket
 
 	std::string _filename;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,10 @@ int main() {
 	Quaternion<double> start_ornt(cos(angle/2.0), sin(angle/2.0)*0.707, sin(angle/2.0)*0.707, 0);
 	rocket.set_q_ornt(start_ornt);
 
+	// Construct some sensors
+	Accelerometer accel1("LSM9_accel", rocket, 100);
+	Gyroscope gyro1("LSM9_gyro", rocket, 100);
+
 	// 3.5 second burn time @ 1500 Newton constant thrust (L ish motor I think)
 	SolidMotor motor(3.5, 4000.0);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@ int main() {
 
 	// Construct some sensors
 	Accelerometer accel1("LSM9_accel", rocket, 100);
+	accel1.enable_noise_injection();
 	Gyroscope gyro1("LSM9_gyro", rocket, 100);
 
 	// 3.5 second burn time @ 1500 Newton constant thrust (L ish motor I think)
@@ -38,6 +39,9 @@ int main() {
 	// std::vector<Sensor&> sensors;
 
 	Simulation sim(0.01, engine, rocket, motor, "sim_data/data.csv");
+	
+	sim.add_sensor(&accel1);
+	// sim.add_sensor(&gyro1);
 
 	std::cout << "Running Sim!" << std::endl;
 


### PR DESCRIPTION
Introducing the ability to add sensors to a particular `Simulation` class instance.

Chose to put the sensors in the `Simulation` class rather than `Rocket` to prevent a circular dependency issue and for easier access to member functions.

Also added Gaussian noise and constant bias injection to simulated sensor measurements.