### PR TITLE
Cleaned up code to better match Google C++ style guide

### DIFF
--- a/lib/Vector3/Vector3.cpp
+++ b/lib/Vector3/Vector3.cpp
@@ -1,109 +1,104 @@
-#include <math.h>
-
 #include "Vector3.h"
 
+#include <math.h>
+
 Vector3::Vector3(const Vector3& rhs) {
-	x = rhs.x;
-	y = rhs.y;
-	z = rhs.z;
+    x = rhs.x;
+    y = rhs.y;
+    z = rhs.z;
 }
 
 Vector3 Vector3::operator+(const Vector3& rhs) const {
-	return Vector3(x+rhs.x, y+rhs.y, z+rhs.z);
+    return Vector3(x + rhs.x, y + rhs.y, z + rhs.z);
 }
 
 Vector3 Vector3::operator-(const Vector3& rhs) const {
-	return Vector3(x-rhs.x, y-rhs.y, z-rhs.z);
+    return Vector3(x - rhs.x, y - rhs.y, z - rhs.z);
 }
 
-Vector3 Vector3::operator-() const {
-	return Vector3(-x, -y, -z);
-}
+Vector3 Vector3::operator-() const { return Vector3(-x, -y, -z); }
 
 Vector3 Vector3::operator*(double scalar) const {
-	return Vector3(x*scalar, y*scalar, z*scalar);
+    return Vector3(x * scalar, y * scalar, z * scalar);
 }
 
 Vector3 operator*(double scalar, const Vector3& rhs) {
-	return Vector3(rhs.x*scalar, rhs.y*scalar, rhs.z*scalar);
+    return Vector3(rhs.x * scalar, rhs.y * scalar, rhs.z * scalar);
 }
 
 Vector3 Vector3::operator/(double scalar) const {
-	return Vector3(x/scalar, y/scalar, z/scalar);
+    return Vector3(x / scalar, y / scalar, z / scalar);
 }
 
 Vector3& Vector3::operator+=(const Vector3& rhs) {
-	x += rhs.x;
-	y += rhs.y;
-	z += rhs.z;
-	return *this;
+    x += rhs.x;
+    y += rhs.y;
+    z += rhs.z;
+    return *this;
 }
 
 Vector3& Vector3::operator-=(const Vector3& rhs) {
-	x -= rhs.x;
-	y -= rhs.y;
-	z -= rhs.z;
-	return *this;
+    x -= rhs.x;
+    y -= rhs.y;
+    z -= rhs.z;
+    return *this;
 }
 
 Vector3& Vector3::operator*=(double scalar) {
-	x *= scalar;
-	y *= scalar;
-	z *= scalar;
-	return *this;
+    x *= scalar;
+    y *= scalar;
+    z *= scalar;
+    return *this;
 }
 
 Vector3& Vector3::operator/=(double scalar) {
-	x /= scalar;
-	y /= scalar;
-	z /= scalar;
-	return *this;
+    x /= scalar;
+    y /= scalar;
+    z /= scalar;
+    return *this;
 }
 
 Vector3& Vector3::operator=(const Vector3& rhs) {
-	x = rhs.x;
-	y = rhs.y;
-	z = rhs.z;
-	return *this;
+    x = rhs.x;
+    y = rhs.y;
+    z = rhs.z;
+    return *this;
 }
 
 Vector3 Vector3::cross(const Vector3& rhs) const {
-	return Vector3(y*rhs.z - z*rhs.y,
-				   -(x*rhs.z - z*rhs.x),
-			       x*rhs.y - y*rhs.x);
+    return Vector3(y * rhs.z - z * rhs.y, -(x * rhs.z - z * rhs.x),
+                   x * rhs.y - y * rhs.x);
 }
 
 double Vector3::dot(const Vector3& rhs) const {
-	return x*rhs.x + y*rhs.y + z*rhs.z;
+    return x * rhs.x + y * rhs.y + z * rhs.z;
 }
 
 double Vector3::magnitude() const {
-	return sqrt(pow(x,2) + pow(y,2) + pow(z,2));
+    return sqrt(pow(x, 2) + pow(y, 2) + pow(z, 2));
 }
 
-double Vector3::magnitude2() const {
-	return pow(x,2) + pow(y,2) + pow(z,2);
-}
+double Vector3::magnitude2() const { return pow(x, 2) + pow(y, 2) + pow(z, 2); }
 
 void Vector3::normalize() {
-	double mag = magnitude();
-	if (mag > 0.0) {
-		(*this) /= magnitude();
-	}
+    double mag = magnitude();
+    if (mag > 0.0) {
+        (*this) /= magnitude();
+    }
 }
 
 Vector3 Vector3::normalized() {
-	double mag = magnitude();
-	if (mag > 0.0) {
-		return Vector3(x/mag, y/mag, z/mag);
-	} else {
-		return Vector3();
-	}
+    double mag = magnitude();
+    if (mag > 0.0) {
+        return Vector3(x / mag, y / mag, z / mag);
+    } else {
+        return Vector3();
+    }
 }
 
 void Vector3::randomize(std::default_random_engine& generator,
-						std::normal_distribution<double>& dist) {
-		x = dist(generator);
-		y = dist(generator);
-		z = dist(generator);
+                        std::normal_distribution<double>& dist) {
+    x = dist(generator);
+    y = dist(generator);
+    z = dist(generator);
 }

--- a/lib/Vector3/Vector3.h
+++ b/lib/Vector3/Vector3.h
@@ -5,37 +5,36 @@
 #include <random>
 
 class Vector3 {
-public:
+   public:
     double x;
     double y;
     double z;
 
-	Vector3(): x(0), y(0), z(0) {};
-	Vector3(double _x, double _y, double _z): x(_x), y(_y), z(_z) {};
-	Vector3(const Vector3& rhs);
+    Vector3() : x(0), y(0), z(0){};
+    Vector3(double _x, double _y, double _z) : x(_x), y(_y), z(_z){};
+    Vector3(const Vector3& rhs);
 
-	Vector3 operator+(const Vector3& rhs) const;
-	Vector3 operator-(const Vector3& rhs) const;
-	Vector3 operator-() const;
-	Vector3 operator*(double scalar) const;
-	Vector3 operator/(double scalar) const;
-	Vector3& operator+=(const Vector3& rhs);
-	Vector3& operator-=(const Vector3& rhs);
-	Vector3& operator*=(double scalar);
-	Vector3& operator/=(double scalar);
-	Vector3& operator=(const Vector3& rhs);
+    Vector3 operator+(const Vector3& rhs) const;
+    Vector3 operator-(const Vector3& rhs) const;
+    Vector3 operator-() const;
+    Vector3 operator*(double scalar) const;
+    Vector3 operator/(double scalar) const;
+    Vector3& operator+=(const Vector3& rhs);
+    Vector3& operator-=(const Vector3& rhs);
+    Vector3& operator*=(double scalar);
+    Vector3& operator/=(double scalar);
+    Vector3& operator=(const Vector3& rhs);
 
-	Vector3 cross (const Vector3& rhs) const;
-	double dot (const Vector3& rhs) const;
+    Vector3 cross(const Vector3& rhs) const;
+    double dot(const Vector3& rhs) const;
 
-	double magnitude() const;
-	double magnitude2() const;
-	void normalize();
-	Vector3 normalized();
+    double magnitude() const;
+    double magnitude2() const;
+    void normalize();
+    Vector3 normalized();
 
-	void randomize(std::default_random_engine& generator,
-				   std::normal_distribution<double>& dist);
-
+    void randomize(std::default_random_engine& generator,
+                   std::normal_distribution<double>& dist);
 };
 
 Vector3 operator*(double scalar, const Vector3& rhs);

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -2,23 +2,25 @@
  * @file 		PhysicsEngine.cpp
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		PhysicsEngine class member function implementations 
+ * @brief 		PhysicsEngine class member function implementations
  *
  * The PhysicsEngine class encapsulates a particular algorithm that is used
- * to advance the state of the simulation in time. These algorithms are 
+ * to advance the state of the simulation in time. These algorithms are
  * commonly responsible for calculating time varying quantities that govern
  * the trajectory of the rocket, such as angular and axial acceleration.
  *
  */
 
-#include <string>
-#include <vector>
+#include "PhysicsEngine.h"
+
 #include <math.h>
 
-#include "PhysicsEngine.h"
+#include <string>
+#include <vector>
+
 #include "Rocket.h"
-#include "quaternion.h"
 #include "Vector3.h"
+#include "quaternion.h"
 
 #define RAD2DEG (180.0 / 3.14159265);
 
@@ -28,148 +30,144 @@
  * @param tStamp Current simulation timestamp
  * @param tStep Simulation time step size
  */
-void ForwardEuler::march_step(double tStamp, double tStep)
-{
+void ForwardEuler::march_step(double tStamp, double tStep) {
+    /*************** Retrieve instantaneous rocket parameters *****************/
 
-	/*************** Retrieve instantaneous rocket parameters *****************/
+    // Inertial frame dynamics parameters
+    static Vector3 r_vect_if = _rocket.get_r_vect();
+    static Vector3 r_dot_if = _rocket.get_r_dot();
+    static Vector3 r_ddot_if = _rocket.get_r_ddot();
+    static Vector3 w_vect_if = _rocket.get_w_vect();
+    static Vector3 w_dot_if = _rocket.get_w_dot();
+    static Vector3 f_net_if = _rocket.get_f_net();
+    static Vector3 t_net_if = _rocket.get_t_net();
 
-	// Inertial frame dynamics parameters
-	static Vector3 r_vect_if = _rocket.get_r_vect();
-	static Vector3 r_dot_if = _rocket.get_r_dot();
-	static Vector3 r_ddot_if = _rocket.get_r_ddot();
-	static Vector3 w_vect_if = _rocket.get_w_vect();
-	static Vector3 w_dot_if = _rocket.get_w_dot();
-	static Vector3 f_net_if = _rocket.get_f_net();
-	static Vector3 t_net_if = _rocket.get_t_net();
+    // Quaternion from inertial to rocket frame
+    static Quaternion<double> q_ornt = _rocket.get_q_ornt();
 
-	// Quaternion from inertial to rocket frame
-	static Quaternion<double> q_ornt = _rocket.get_q_ornt();
+    // CG to Cp vector
+    static Vector3 Cp_vect_rf = _rocket.get_Cp_vect();
 
-	// CG to Cp vector
-	static Vector3 Cp_vect_rf = _rocket.get_Cp_vect();
+    // Get moment of inertia tenspr
+    static double I_tens[9];
+    _rocket.get_I(I_tens);
 
-	// Get moment of inertia tenspr
-	static double I_tens[9];
-	_rocket.get_I(I_tens);
+    // Static parameters
+    static double mass = _rocket.get_mass();
+    // static double d_ref = _rocket.get_d_ref();
+    static double A_ref = _rocket.get_A_ref();
+    static double Cna = _rocket.get_Cna();
+    static double Cd = _rocket.get_Cd();
 
-	// Static parameters
-	static double mass = _rocket.get_mass();
-	// static double d_ref = _rocket.get_d_ref();
-	static double A_ref = _rocket.get_A_ref();
-	static double Cna = _rocket.get_Cna();
-	static double Cd = _rocket.get_Cd();
+    // Motor thrust vector, rocket frame
+    static Vector3 thrust_rf = _motor.get_thrust(tStamp);
 
-	// Motor thrust vector, rocket frame
-	static Vector3 thrust_rf = _motor.get_thrust(tStamp);
+    /********************* Calculate forces and torques ***********************/
 
-	/********************* Calculate forces and torques ***********************/
+    static Vector3 f_aero_rf;  // Aerodynamic forces, rocket frame
+    static Vector3 t_aero_rf;  // Aerodynamic torques, rocket frame
+    static Vector3 f_aero_if;  // Aerodynamic forces, inertial frame
+    static Vector3 t_aero_if;  // Aerodynamic torques, inertial frame
 
-	static Vector3 f_aero_rf;	// Aerodynamic forces, rocket frame
-	static Vector3 t_aero_rf;	// Aerodynamic torques, rocket frame
-	static Vector3 f_aero_if;	// Aerodynamic forces, inertial frame
-	static Vector3 t_aero_if;	// Aerodynamic torques, inertial frame
+    static Vector3 f_net_rf;
+    static Vector3 t_net_rf;
 
-	static Vector3 f_net_rf;
-	static Vector3 t_net_rf;
+    if (r_dot_if.magnitude() > 0.01) {
+        // if (true) {
 
-	if (r_dot_if.magnitude() > 0.01) {
-	// if (true) {
+        Vector3 rocket_axis_rf(0, 0, 1);
 
-		Vector3 rocket_axis_rf(0,0,1);
+        Vector3 v_rf;
+        v_rf = _rocket.i2r(r_dot_if);
 
-		Vector3 v_rf;
-		v_rf = _rocket.i2r(r_dot_if);
+        // printf("v_rf: <%f, %f, %f>\n", v_rf.x, v_rf.y, v_rf.z);
 
-		// printf("v_rf: <%f, %f, %f>\n", v_rf.x, v_rf.y, v_rf.z);
+        double alpha = acos(v_rf.z / v_rf.magnitude());
 
-		double alpha = acos(v_rf.z / v_rf.magnitude());
+        Vector3 f_N_rf;
 
-		Vector3 f_N_rf;
+        double f_N_mag = Cna * alpha * 0.5 * 1.225 * v_rf.magnitude2() * A_ref;
+        f_N_rf.x = -v_rf.x;
+        f_N_rf.y = -v_rf.y;
+        f_N_rf.z = 0;
+        f_N_rf.normalize();
+        f_N_rf = f_N_rf * f_N_mag;
 
-		double f_N_mag = Cna * alpha * 0.5 * 1.225 * v_rf.magnitude2() * A_ref;
-		f_N_rf.x = -v_rf.x;
-		f_N_rf.y = -v_rf.y;
-		f_N_rf.z = 0;
-		f_N_rf.normalize();
-		f_N_rf = f_N_rf * f_N_mag;
+        // printf("f_N_mag: %f\n", f_N_mag);
+        // printf("f_N_rf: <%f, %f, %f>\n", f_N_rf.x, f_N_rf.y, f_N_rf.z);
 
-		// printf("f_N_mag: %f\n", f_N_mag);
-		// printf("f_N_rf: <%f, %f, %f>\n", f_N_rf.x, f_N_rf.y, f_N_rf.z);
+        double f_D_mag = Cd * 0.5 * 1.225 * v_rf.magnitude2();
+        Vector3 f_D_rf(0, 0, -f_D_mag);
 
-		double f_D_mag = Cd * 0.5 * 1.225 * v_rf.magnitude2();
-		Vector3 f_D_rf(0, 0, -f_D_mag);
+        // printf("f_D_rf: <%f, %f, %f>\n", f_D_rf.x, f_D_rf.y, f_D_rf.z);
 
-		// printf("f_D_rf: <%f, %f, %f>\n", f_D_rf.x, f_D_rf.y, f_D_rf.z);
+        f_aero_rf = f_N_rf + f_D_rf;
 
-		f_aero_rf = f_N_rf + f_D_rf;
+        // printf("f_aero_rf: <%f, %f, %f>\n\n", f_aero_rf.x, f_aero_rf.y,
+        // f_aero_rf.z);
 
-		// printf("f_aero_rf: <%f, %f, %f>\n\n", f_aero_rf.x, f_aero_rf.y, f_aero_rf.z);
+        // t_aero_rf = f_aero_rf.cross(Cp_vect_rf);
+        t_aero_rf = Cp_vect_rf.cross(f_aero_rf);
 
-		// t_aero_rf = f_aero_rf.cross(Cp_vect_rf);
-		t_aero_rf = Cp_vect_rf.cross(f_aero_rf);
+    } else {
+        f_aero_rf.x = 0;
+        f_aero_rf.y = 0;
+        f_aero_rf.z = 0;
 
-	}
-	else {
-		f_aero_rf.x = 0;
-		f_aero_rf.y = 0;
-		f_aero_rf.z = 0;
+        t_aero_rf.x = 0;
+        t_aero_rf.y = 0;
+        t_aero_rf.z = 0;
+    }
 
-		t_aero_rf.x = 0;
-		t_aero_rf.y = 0;
-		t_aero_rf.z = 0;
-	}
+    f_net_if = _rocket.r2i(f_aero_rf + thrust_rf);
+    f_net_if.z -= mass * 9.81;
 
-	f_net_if = _rocket.r2i(f_aero_rf + thrust_rf);
-	f_net_if.z -= mass * 9.81;
+    t_net_if = _rocket.r2i(t_aero_rf);
 
-	t_net_if = _rocket.r2i(t_aero_rf);
+    /************************** Perform euler step ****************************/
 
-	/************************** Perform euler step ****************************/
+    r_vect_if += r_dot_if * tStep;
+    r_dot_if += r_ddot_if * tStep;
+    r_ddot_if = f_net_if / mass;
 
-	r_vect_if += r_dot_if * tStep;
-	r_dot_if += r_ddot_if * tStep;
-	r_ddot_if = f_net_if / mass;
-
-	// Assemble instantaneous rotation quaternion
+    // Assemble instantaneous rotation quaternion
     double w_mag = w_vect_if.magnitude();
-	if (w_mag > 0.000001) {
-		Quaternion<double> q_rot;
-	    q_rot.Set(cos(w_mag/2.0),
-				  (w_vect_if.x/w_mag)*sin(w_mag/2.0),
-				  (w_vect_if.y/w_mag)*sin(w_mag/2.0),
-				  (w_vect_if.z/w_mag)*sin(w_mag/2.0));
+    if (w_mag > 0.000001) {
+        Quaternion<double> q_rot;
+        q_rot.Set(cos(w_mag / 2.0), (w_vect_if.x / w_mag) * sin(w_mag / 2.0),
+                  (w_vect_if.y / w_mag) * sin(w_mag / 2.0),
+                  (w_vect_if.z / w_mag) * sin(w_mag / 2.0));
 
-		// Apply instantaneous rotation
-		q_ornt = q_ornt * q_rot;
-		q_ornt.Normalize();
-	}
+        // Apply instantaneous rotation
+        q_ornt = q_ornt * q_rot;
+        q_ornt.Normalize();
+    }
 
-	w_vect_if += w_dot_if * tStep;
+    w_vect_if += w_dot_if * tStep;
 
-	w_dot_if.x = t_net_if.x / I_tens[0];
-	w_dot_if.y = t_net_if.y / I_tens[4];
-	w_dot_if.z = t_net_if.z / I_tens[8];
+    w_dot_if.x = t_net_if.x / I_tens[0];
+    w_dot_if.y = t_net_if.y / I_tens[4];
+    w_dot_if.z = t_net_if.z / I_tens[8];
 
-	// Naively accounting for launch rail
-	if (r_vect_if.magnitude() < 4.50) {
-		w_dot_if.x = 0;
-		w_dot_if.y = 0;
-		w_dot_if.z = 0;
-		w_vect_if.x = 0;
-		w_vect_if.y = 0;
-		w_vect_if.z = 0;
-	}
+    // Naively accounting for launch rail
+    if (r_vect_if.magnitude() < 4.50) {
+        w_dot_if.x = 0;
+        w_dot_if.y = 0;
+        w_dot_if.z = 0;
+        w_vect_if.x = 0;
+        w_vect_if.y = 0;
+        w_vect_if.z = 0;
+    }
 
-	_rocket.set_f_net(f_net_if);
-	_rocket.set_t_net(t_net_if);
+    _rocket.set_f_net(f_net_if);
+    _rocket.set_t_net(t_net_if);
 
-	_rocket.set_r_vect(r_vect_if);
-	_rocket.set_r_dot(r_dot_if);
-	_rocket.set_r_ddot(r_ddot_if);
+    _rocket.set_r_vect(r_vect_if);
+    _rocket.set_r_dot(r_dot_if);
+    _rocket.set_r_ddot(r_ddot_if);
 
-	_rocket.set_q_ornt(q_ornt);
+    _rocket.set_q_ornt(q_ornt);
 
-	_rocket.set_w_vect(w_vect_if);
-	_rocket.set_w_dot(w_dot_if);
-
+    _rocket.set_w_vect(w_vect_if);
+    _rocket.set_w_dot(w_dot_if);
 }

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -34,33 +34,33 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
     /*************** Retrieve instantaneous rocket parameters *****************/
 
     // Inertial frame dynamics parameters
-    static Vector3 r_vect_if = _rocket.get_r_vect();
-    static Vector3 r_dot_if = _rocket.get_r_dot();
-    static Vector3 r_ddot_if = _rocket.get_r_ddot();
-    static Vector3 w_vect_if = _rocket.get_w_vect();
-    static Vector3 w_dot_if = _rocket.get_w_dot();
-    static Vector3 f_net_if = _rocket.get_f_net();
-    static Vector3 t_net_if = _rocket.get_t_net();
+    static Vector3 r_vect_if = rocket_.get_r_vect();
+    static Vector3 r_dot_if = rocket_.get_r_dot();
+    static Vector3 r_ddot_if = rocket_.get_r_ddot();
+    static Vector3 w_vect_if = rocket_.get_w_vect();
+    static Vector3 w_dot_if = rocket_.get_w_dot();
+    static Vector3 f_net_if = rocket_.get_f_net();
+    static Vector3 t_net_if = rocket_.get_t_net();
 
     // Quaternion from inertial to rocket frame
-    static Quaternion<double> q_ornt = _rocket.get_q_ornt();
+    static Quaternion<double> q_ornt = rocket_.get_q_ornt();
 
     // CG to Cp vector
-    static Vector3 Cp_vect_rf = _rocket.get_Cp_vect();
+    static Vector3 Cp_vect_rf = rocket_.get_Cp_vect();
 
     // Get moment of inertia tenspr
     static double I_tens[9];
-    _rocket.get_I(I_tens);
+    rocket_.get_I(I_tens);
 
     // Static parameters
-    static double mass = _rocket.get_mass();
-    // static double d_ref = _rocket.get_d_ref();
-    static double A_ref = _rocket.get_A_ref();
-    static double Cna = _rocket.get_Cna();
-    static double Cd = _rocket.get_Cd();
+    static double mass = rocket_.get_mass();
+    // static double d_ref = rocket_.get_d_ref();
+    static double A_ref = rocket_.get_A_ref();
+    static double Cna = rocket_.get_Cna();
+    static double Cd = rocket_.get_Cd();
 
     // Motor thrust vector, rocket frame
-    static Vector3 thrust_rf = _motor.get_thrust(tStamp);
+    static Vector3 thrust_rf = motor_.get_thrust(tStamp);
 
     /********************* Calculate forces and torques ***********************/
 
@@ -78,7 +78,7 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
         Vector3 rocket_axis_rf(0, 0, 1);
 
         Vector3 v_rf;
-        v_rf = _rocket.i2r(r_dot_if);
+        v_rf = rocket_.i2r(r_dot_if);
 
         // printf("v_rf: <%f, %f, %f>\n", v_rf.x, v_rf.y, v_rf.z);
 
@@ -119,10 +119,10 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
         t_aero_rf.z = 0;
     }
 
-    f_net_if = _rocket.r2i(f_aero_rf + thrust_rf);
+    f_net_if = rocket_.r2i(f_aero_rf + thrust_rf);
     f_net_if.z -= mass * 9.81;
 
-    t_net_if = _rocket.r2i(t_aero_rf);
+    t_net_if = rocket_.r2i(t_aero_rf);
 
     /************************** Perform euler step ****************************/
 
@@ -159,15 +159,15 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
         w_vect_if.z = 0;
     }
 
-    _rocket.set_f_net(f_net_if);
-    _rocket.set_t_net(t_net_if);
+    rocket_.set_f_net(f_net_if);
+    rocket_.set_t_net(t_net_if);
 
-    _rocket.set_r_vect(r_vect_if);
-    _rocket.set_r_dot(r_dot_if);
-    _rocket.set_r_ddot(r_ddot_if);
+    rocket_.set_r_vect(r_vect_if);
+    rocket_.set_r_dot(r_dot_if);
+    rocket_.set_r_ddot(r_ddot_if);
 
-    _rocket.set_q_ornt(q_ornt);
+    rocket_.set_q_ornt(q_ornt);
 
-    _rocket.set_w_vect(w_vect_if);
-    _rocket.set_w_dot(w_dot_if);
+    rocket_.set_w_vect(w_vect_if);
+    rocket_.set_w_dot(w_dot_if);
 }

--- a/src/PhysicsEngine.h
+++ b/src/PhysicsEngine.h
@@ -2,7 +2,7 @@
  * @file 		PhysicsEngine.h
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		PhysicsEngine class definition 
+ * @brief 		PhysicsEngine class definition
  *
  * The PhysicsEngine class encapsulates a particular algorithm that is used
  * to advance the state of the simulation in time. These algorithms are
@@ -24,13 +24,13 @@
 class PhysicsEngine {
    public:
     PhysicsEngine(Rocket& rocket, SolidMotor& motor)
-        : _rocket(rocket), _motor(motor){};
+        : rocket_(rocket), motor_(motor){};
 
     virtual void march_step(double tStamp, double tStep) = 0;
 
    protected:
-    Rocket& _rocket;
-    SolidMotor& _motor;
+    Rocket& rocket_;
+    SolidMotor& motor_;
 };
 
 class ForwardEuler : public PhysicsEngine {

--- a/src/PhysicsEngine.h
+++ b/src/PhysicsEngine.h
@@ -1,3 +1,15 @@
+/**
+ * @file 		PhysicsEngine.h
+ * @authors 	Ayberk Yaraneri
+ *
+ * @brief 		PhysicsEngine class definition 
+ *
+ * The PhysicsEngine class encapsulates a particular algorithm that is used
+ * to advance the state of the simulation in time. These algorithms are
+ * commonly responsible for calculating time varying quantities that govern
+ * the trajectory of the rocket, such as angular and axial acceleration.
+ *
+ */
 
 #ifndef _PHYSICS_ENGINE_H_
 #define _PHYSICS_ENGINE_H_
@@ -5,30 +17,28 @@
 #include <string>
 #include <vector>
 
-#include "Rocket.h"
 #include "Propulsion.h"
+#include "Rocket.h"
 #include "quaternion.h"
 
 class PhysicsEngine {
-	public:
-		PhysicsEngine(Rocket& rocket, SolidMotor& motor) :
-			_rocket(rocket), _motor(motor) {};
+   public:
+    PhysicsEngine(Rocket& rocket, SolidMotor& motor)
+        : _rocket(rocket), _motor(motor){};
 
-		virtual void march_step(double tStamp, double tStep) = 0;
+    virtual void march_step(double tStamp, double tStep) = 0;
 
-	protected:
-		Rocket& _rocket;
-		SolidMotor& _motor;
-
+   protected:
+    Rocket& _rocket;
+    SolidMotor& _motor;
 };
 
-
 class ForwardEuler : public PhysicsEngine {
-	public:
-		ForwardEuler(Rocket& rocket, SolidMotor& motor) :
-			PhysicsEngine(rocket, motor) {};
+   public:
+    ForwardEuler(Rocket& rocket, SolidMotor& motor)
+        : PhysicsEngine(rocket, motor){};
 
-		void march_step(double tStamp, double tStep);
+    void march_step(double tStamp, double tStep);
 };
 
 #endif

--- a/src/Propulsion.cpp
+++ b/src/Propulsion.cpp
@@ -1,20 +1,21 @@
 /**
- * @file 		Propulsion.cpp	
+ * @file 		Propulsion.cpp
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		Member function implementations of propulsion component classes 
+ * @brief 		Member function implementations of propulsion component
+ * classes
  *
  * The classes defined here represent rocket propulsion components. While these
- * objects will usually represent rocket motors, they can also be defined to 
+ * objects will usually represent rocket motors, they can also be defined to
  * represent components like gas thrusters or other force enducing mechanisms.
  *
  */
 
+#include "Propulsion.h"
+
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
-
-#include "Propulsion.h"
 
 /**
  * @brief Transitions state of SolidMotor to ignited (producing thrust)
@@ -23,9 +24,9 @@
  */
 
 void SolidMotor::ignite(double tStamp) {
-	_ignition = true;
-	_ignition_tStamp = tStamp;
-	_current_thrust = _thrust_value;
+    _ignition = true;
+    _ignition_tStamp = tStamp;
+    _current_thrust = _thrust_value;
 }
 
 /**
@@ -35,17 +36,17 @@ void SolidMotor::ignite(double tStamp) {
  * @param vector Vector reference to overwrite with motor's thrust vector
  */
 void SolidMotor::get_thrust(double tStamp, Vector3& vector) {
-	if (_ignition == true) {
-		if ((tStamp - _ignition_tStamp) <= _max_burn_duration) {
-			vector.x = 0.0;
-			vector.y = 0.0;
-			vector.z = _current_thrust;
-			return;
-		}
-	}
-	vector.x = 0.0;
-	vector.y = 0.0;
-	vector.z = 0.0;
+    if (_ignition == true) {
+        if ((tStamp - _ignition_tStamp) <= _max_burn_duration) {
+            vector.x = 0.0;
+            vector.y = 0.0;
+            vector.z = _current_thrust;
+            return;
+        }
+    }
+    vector.x = 0.0;
+    vector.y = 0.0;
+    vector.z = 0.0;
 }
 
 /**
@@ -55,18 +56,18 @@ void SolidMotor::get_thrust(double tStamp, Vector3& vector) {
  * @return Vector3 The motor's current thrust vector
  */
 Vector3 SolidMotor::get_thrust(double tStamp) {
-  Vector3 vector;
-  if (_ignition == true) {
-		if ((tStamp - _ignition_tStamp) <= _max_burn_duration) {
-			vector.x = 0.0;
-			vector.y = 0.0;
-			vector.z = _current_thrust;
-			return vector;
-		}
-	}
-	vector.x = 0.0;
-	vector.y = 0.0;
-	vector.z = 0.0;
+    Vector3 vector;
+    if (_ignition == true) {
+        if ((tStamp - _ignition_tStamp) <= _max_burn_duration) {
+            vector.x = 0.0;
+            vector.y = 0.0;
+            vector.z = _current_thrust;
+            return vector;
+        }
+    }
+    vector.x = 0.0;
+    vector.y = 0.0;
+    vector.z = 0.0;
 
-  return vector;
+    return vector;
 }

--- a/src/Propulsion.cpp
+++ b/src/Propulsion.cpp
@@ -24,9 +24,9 @@
  */
 
 void SolidMotor::ignite(double tStamp) {
-    _ignition = true;
-    _ignition_tStamp = tStamp;
-    _current_thrust = _thrust_value;
+    ignition_ = true;
+    ignition_tStamp_ = tStamp;
+    current_thrust_ = thrust_value_;
 }
 
 /**
@@ -36,11 +36,11 @@ void SolidMotor::ignite(double tStamp) {
  * @param vector Vector reference to overwrite with motor's thrust vector
  */
 void SolidMotor::get_thrust(double tStamp, Vector3& vector) {
-    if (_ignition == true) {
-        if ((tStamp - _ignition_tStamp) <= _max_burn_duration) {
+    if (ignition_ == true) {
+        if ((tStamp - ignition_tStamp_) <= max_burn_duration_) {
             vector.x = 0.0;
             vector.y = 0.0;
-            vector.z = _current_thrust;
+            vector.z = current_thrust_;
             return;
         }
     }
@@ -57,11 +57,11 @@ void SolidMotor::get_thrust(double tStamp, Vector3& vector) {
  */
 Vector3 SolidMotor::get_thrust(double tStamp) {
     Vector3 vector;
-    if (_ignition == true) {
-        if ((tStamp - _ignition_tStamp) <= _max_burn_duration) {
+    if (ignition_ == true) {
+        if ((tStamp - ignition_tStamp_) <= max_burn_duration_) {
             vector.x = 0.0;
             vector.y = 0.0;
-            vector.z = _current_thrust;
+            vector.z = current_thrust_;
             return vector;
         }
     }

--- a/src/Propulsion.h
+++ b/src/Propulsion.h
@@ -23,20 +23,20 @@
 class SolidMotor {
    public:
     SolidMotor(double max_burn_duration, double thrust_value)
-        : _ignition(false),
-          _max_burn_duration(max_burn_duration),
-          _thrust_value(thrust_value){};
+        : ignition_(false),
+          max_burn_duration_(max_burn_duration),
+          thrust_value_(thrust_value){};
 
     void ignite(double tStamp);
     void get_thrust(double tStamp, Vector3& vector);
     Vector3 get_thrust(double tStamp);
 
    private:
-    bool _ignition;
-    double _max_burn_duration;
-    double _ignition_tStamp;
-    double _current_thrust;
-    double _thrust_value;
+    bool ignition_;
+    double max_burn_duration_;
+    double ignition_tStamp_;
+    double current_thrust_;
+    double thrust_value_;
 };
 
 #endif

--- a/src/Propulsion.h
+++ b/src/Propulsion.h
@@ -1,11 +1,11 @@
 /**
- * @file 		Propulsion.h	
+ * @file 		Propulsion.h
  * @authors 	Ayberk Yaraneri
  *
  * @brief 		Class definitions for rocket propulsion components
  *
  * The classes defined here represent rocket propulsion components. While these
- * objects will usually represent rocket motors, they can also be defined to 
+ * objects will usually represent rocket motors, they can also be defined to
  * represent components like gas thrusters or other force enducing mechanisms.
  *
  */
@@ -21,22 +21,22 @@
 #include "Vector3.h"
 
 class SolidMotor {
-public:
-	SolidMotor(double max_burn_duration, double thrust_value):
-		_ignition(false),
-		_max_burn_duration(max_burn_duration),
-		_thrust_value(thrust_value) {};
+   public:
+    SolidMotor(double max_burn_duration, double thrust_value)
+        : _ignition(false),
+          _max_burn_duration(max_burn_duration),
+          _thrust_value(thrust_value){};
 
-	void ignite(double tStamp);
-	void get_thrust(double tStamp, Vector3& vector);
-  Vector3 get_thrust(double tStamp);
+    void ignite(double tStamp);
+    void get_thrust(double tStamp, Vector3& vector);
+    Vector3 get_thrust(double tStamp);
 
-private:
-	bool _ignition;
-	double _max_burn_duration;
-	double _ignition_tStamp;
-	double _current_thrust;
-	double _thrust_value;
+   private:
+    bool _ignition;
+    double _max_burn_duration;
+    double _ignition_tStamp;
+    double _current_thrust;
+    double _thrust_value;
 };
 
 #endif

--- a/src/Rocket.cpp
+++ b/src/Rocket.cpp
@@ -2,39 +2,38 @@
  * @file 		Rocket.cpp
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		Rocket class member function implementations 
+ * @brief 		Rocket class member function implementations
  *
- * The rocket class encapsulates all physical quantities and parameters of the 
- * Rocket. The class also contains references to child objects representing 
+ * The rocket class encapsulates all physical quantities and parameters of the
+ * Rocket. The class also contains references to child objects representing
  * components like sensors and rocket motors along with mechanisms to extract
- * useful information about the rocket's state/trajectory. 
+ * useful information about the rocket's state/trajectory.
  *
  */
 
+#include "Rocket.h"
+
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
 
-#include "Rocket.h"
-#include "quaternion.h"
 #include "Vector3.h"
+#include "quaternion.h"
 
 Rocket::Rocket() {
+    _r_vect = Vector3();
+    _r_dot = Vector3();
+    _r_ddot = Vector3();
 
-	_r_vect = Vector3();
-	_r_dot = Vector3();
-	_r_ddot = Vector3();
+    _q_ornt = Quaternion<double>(1, 0, 0, 0);
 
-	_q_ornt = Quaternion<double>(1, 0, 0, 0);
+    _w_vect = Vector3();
+    _w_dot = Vector3();
 
-	_w_vect = Vector3();
-	_w_dot = Vector3();
+    _f_net = Vector3();
+    _t_net = Vector3();
 
-	_f_net = Vector3();
-	_t_net = Vector3();
-
-	_Cp_vect = Vector3(0, 0, -(_nose_to_cp - _nose_to_cg));
-
+    _Cp_vect = Vector3(0, 0, -(_nose_to_cp - _nose_to_cg));
 }
 
 /**
@@ -43,7 +42,7 @@ Rocket::Rocket() {
  * @param nose_to_cg Reference to double to overwrite with calculated distance
  */
 void Rocket::get_nose_to_cg(double& nose_to_cg) const {
-	nose_to_cg = _nose_to_cg;
+    nose_to_cg = _nose_to_cg;
 }
 
 /**
@@ -55,10 +54,10 @@ void Rocket::get_nose_to_cg(double& nose_to_cg) const {
  * @param nose_to_cg Distance between tip of nosecone and CG
  */
 void Rocket::set_nose_to_cg(double& nose_to_cg) {
-	_nose_to_cg = nose_to_cg;
-	_Cp_vect.x = 0;
-	_Cp_vect.y = 0;
-	_Cp_vect.z = -(_nose_to_cp - _nose_to_cg);
+    _nose_to_cg = nose_to_cg;
+    _Cp_vect.x = 0;
+    _Cp_vect.y = 0;
+    _Cp_vect.z = -(_nose_to_cp - _nose_to_cg);
 }
 
 /**
@@ -67,7 +66,7 @@ void Rocket::set_nose_to_cg(double& nose_to_cg) {
  * @param nose_to_cp Reference to double to overwrite with calculated distance
  */
 void Rocket::get_nose_to_cp(double& nose_to_cp) const {
-	nose_to_cp = _nose_to_cp;
+    nose_to_cp = _nose_to_cp;
 }
 
 /**
@@ -79,10 +78,10 @@ void Rocket::get_nose_to_cp(double& nose_to_cp) const {
  * @param nose_to_cg Distance between tip of nosecone and CG
  */
 void Rocket::set_nose_to_cp(double& nose_to_cp) {
-	_nose_to_cp = nose_to_cp;
-	_Cp_vect.x = 0;
-	_Cp_vect.y = 0;
-	_Cp_vect.z = -(_nose_to_cp - _nose_to_cg);
+    _nose_to_cp = nose_to_cp;
+    _Cp_vect.x = 0;
+    _Cp_vect.y = 0;
+    _Cp_vect.z = -(_nose_to_cp - _nose_to_cg);
 }
 
 /**
@@ -90,9 +89,7 @@ void Rocket::set_nose_to_cp(double& nose_to_cp) {
  *
  * @param vector Reference to a vector to overwrite with CG-to-CP vector
  */
-void Rocket::get_Cp_vect(Vector3& vector) const {
-	vector = _Cp_vect;
-}
+void Rocket::get_Cp_vect(Vector3& vector) const { vector = _Cp_vect; }
 
 /**
  * @brief Performs a quaternion rotation to translate a vector from the inertial
@@ -102,13 +99,13 @@ void Rocket::get_Cp_vect(Vector3& vector) const {
  * @return Vector3 The rotated vector represented in the rocket body frame
  */
 Vector3 Rocket::i2r(Vector3 vector) {
-	Quaternion<double> p(0, vector.x, vector.y, vector.z);
-	p = (_q_ornt.conj() * p) * _q_ornt;
-	Vector3 newVector;
-	newVector.x = p.Getx();
-	newVector.y = p.Gety();
-	newVector.z = p.Getz();
-	return newVector;
+    Quaternion<double> p(0, vector.x, vector.y, vector.z);
+    p = (_q_ornt.conj() * p) * _q_ornt;
+    Vector3 newVector;
+    newVector.x = p.Getx();
+    newVector.y = p.Gety();
+    newVector.z = p.Getz();
+    return newVector;
 }
 
 /**
@@ -119,12 +116,11 @@ Vector3 Rocket::i2r(Vector3 vector) {
  * @return Vector3 The rotated vector represented in the inertial frame
  */
 Vector3 Rocket::r2i(Vector3 vector) {
-	Quaternion<double> p(0, vector.x, vector.y, vector.z);
-	p = (_q_ornt * p) * _q_ornt.conj();
-	Vector3 newVector;
-	newVector.x = p.Getx();
-	newVector.y = p.Gety();
-	newVector.z = p.Getz();
-	return newVector;
+    Quaternion<double> p(0, vector.x, vector.y, vector.z);
+    p = (_q_ornt * p) * _q_ornt.conj();
+    Vector3 newVector;
+    newVector.x = p.Getx();
+    newVector.y = p.Gety();
+    newVector.z = p.Getz();
+    return newVector;
 }
-

--- a/src/Rocket.cpp
+++ b/src/Rocket.cpp
@@ -21,19 +21,9 @@
 #include "quaternion.h"
 
 Rocket::Rocket() {
-    _r_vect = Vector3();
-    _r_dot = Vector3();
-    _r_ddot = Vector3();
+    q_ornt_ = Quaternion<double>(1, 0, 0, 0);
 
-    _q_ornt = Quaternion<double>(1, 0, 0, 0);
-
-    _w_vect = Vector3();
-    _w_dot = Vector3();
-
-    _f_net = Vector3();
-    _t_net = Vector3();
-
-    _Cp_vect = Vector3(0, 0, -(_nose_to_cp - _nose_to_cg));
+    Cp_vect_ = Vector3(0, 0, -(nose_to_cp_ - nose_to_cg_));
 }
 
 /**
@@ -42,7 +32,7 @@ Rocket::Rocket() {
  * @param nose_to_cg Reference to double to overwrite with calculated distance
  */
 void Rocket::get_nose_to_cg(double& nose_to_cg) const {
-    nose_to_cg = _nose_to_cg;
+    nose_to_cg = nose_to_cg_;
 }
 
 /**
@@ -54,10 +44,10 @@ void Rocket::get_nose_to_cg(double& nose_to_cg) const {
  * @param nose_to_cg Distance between tip of nosecone and CG
  */
 void Rocket::set_nose_to_cg(double& nose_to_cg) {
-    _nose_to_cg = nose_to_cg;
-    _Cp_vect.x = 0;
-    _Cp_vect.y = 0;
-    _Cp_vect.z = -(_nose_to_cp - _nose_to_cg);
+    nose_to_cg_ = nose_to_cg;
+    Cp_vect_.x = 0;
+    Cp_vect_.y = 0;
+    Cp_vect_.z = -(nose_to_cp_ - nose_to_cg_);
 }
 
 /**
@@ -66,7 +56,7 @@ void Rocket::set_nose_to_cg(double& nose_to_cg) {
  * @param nose_to_cp Reference to double to overwrite with calculated distance
  */
 void Rocket::get_nose_to_cp(double& nose_to_cp) const {
-    nose_to_cp = _nose_to_cp;
+    nose_to_cp = nose_to_cp_;
 }
 
 /**
@@ -78,10 +68,10 @@ void Rocket::get_nose_to_cp(double& nose_to_cp) const {
  * @param nose_to_cg Distance between tip of nosecone and CG
  */
 void Rocket::set_nose_to_cp(double& nose_to_cp) {
-    _nose_to_cp = nose_to_cp;
-    _Cp_vect.x = 0;
-    _Cp_vect.y = 0;
-    _Cp_vect.z = -(_nose_to_cp - _nose_to_cg);
+    nose_to_cp_ = nose_to_cp;
+    Cp_vect_.x = 0;
+    Cp_vect_.y = 0;
+    Cp_vect_.z = -(nose_to_cp_ - nose_to_cg_);
 }
 
 /**
@@ -89,7 +79,7 @@ void Rocket::set_nose_to_cp(double& nose_to_cp) {
  *
  * @param vector Reference to a vector to overwrite with CG-to-CP vector
  */
-void Rocket::get_Cp_vect(Vector3& vector) const { vector = _Cp_vect; }
+void Rocket::get_Cp_vect(Vector3& vector) const { vector = Cp_vect_; }
 
 /**
  * @brief Performs a quaternion rotation to translate a vector from the inertial
@@ -100,7 +90,7 @@ void Rocket::get_Cp_vect(Vector3& vector) const { vector = _Cp_vect; }
  */
 Vector3 Rocket::i2r(Vector3 vector) {
     Quaternion<double> p(0, vector.x, vector.y, vector.z);
-    p = (_q_ornt.conj() * p) * _q_ornt;
+    p = (q_ornt_.conj() * p) * q_ornt_;
     Vector3 newVector;
     newVector.x = p.Getx();
     newVector.y = p.Gety();
@@ -117,7 +107,7 @@ Vector3 Rocket::i2r(Vector3 vector) {
  */
 Vector3 Rocket::r2i(Vector3 vector) {
     Quaternion<double> p(0, vector.x, vector.y, vector.z);
-    p = (_q_ornt * p) * _q_ornt.conj();
+    p = (q_ornt_ * p) * q_ornt_.conj();
     Vector3 newVector;
     newVector.x = p.Getx();
     newVector.y = p.Gety();

--- a/src/Rocket.h
+++ b/src/Rocket.h
@@ -27,81 +27,81 @@ class Rocket {
     Rocket();
 
     /****************** Get parameters by referece ************************/
-    void get_r_vect(Vector3& vector) const { vector = _r_vect; };
-    void get_r_dot(Vector3& vector) const { vector = _r_dot; };
-    void get_r_ddot(Vector3& vector) const { vector = _r_ddot; };
+    void get_r_vect(Vector3& vector) const { vector = r_vect_; };
+    void get_r_dot(Vector3& vector) const { vector = r_dot_; };
+    void get_r_ddot(Vector3& vector) const { vector = r_ddot_; };
 
-    void get_q_ornt(Quaternion<double>& quatrn) const { quatrn = _q_ornt; };
+    void get_q_ornt(Quaternion<double>& quatrn) const { quatrn = q_ornt_; };
 
     void get_I(double (&array)[9]) const {
         for (int i = 0; i < 9; ++i) {
-            array[i] = _I[i];
+            array[i] = I_[i];
         }
     };
 
-    void get_w_vect(Vector3& vector) const { vector = _w_vect; };
-    void get_w_dot(Vector3& vector) const { vector = _w_dot; };
+    void get_w_vect(Vector3& vector) const { vector = w_vect_; };
+    void get_w_dot(Vector3& vector) const { vector = w_dot_; };
 
-    void get_f_net(Vector3& vector) const { vector = _f_net; };
-    void get_t_net(Vector3& vector) const { vector = _t_net; };
+    void get_f_net(Vector3& vector) const { vector = f_net_; };
+    void get_t_net(Vector3& vector) const { vector = t_net_; };
 
-    void get_mass(double& mass) const { mass = _mass; };
-    void get_d_ref(double& d_ref) const { d_ref = _d_ref; };
-    void get_A_ref(double& A_ref) const { A_ref = _A_ref; };
-    void get_Cna(double& Cna) const { Cna = _Cna; };
-    void get_Cd(double& Cd) const { Cd = _Cd; };
+    void get_mass(double& mass) const { mass = mass_; };
+    void get_d_ref(double& d_ref) const { d_ref = d_ref_; };
+    void get_A_ref(double& A_ref) const { A_ref = A_ref_; };
+    void get_Cna(double& Cna) const { Cna = Cna_; };
+    void get_Cd(double& Cd) const { Cd = Cd_; };
     void get_nose_to_cg(double& nose_to_cg) const;
     void get_nose_to_cp(double& nose_to_cp) const;
 
     void get_Cp_vect(Vector3& vector) const;
 
     /************ Get parameters by value (return by value) ***************/
-    Vector3 get_r_vect() const { return _r_vect; };
-    Vector3 get_r_dot() const { return _r_dot; };
-    Vector3 get_r_ddot() const { return _r_ddot; };
+    Vector3 get_r_vect() const { return r_vect_; };
+    Vector3 get_r_dot() const { return r_dot_; };
+    Vector3 get_r_ddot() const { return r_ddot_; };
 
-    Quaternion<double> get_q_ornt() const { return _q_ornt; };
+    Quaternion<double> get_q_ornt() const { return q_ornt_; };
 
-    Vector3 get_w_vect() const { return _w_vect; };
-    Vector3 get_w_dot() const { return _w_dot; };
+    Vector3 get_w_vect() const { return w_vect_; };
+    Vector3 get_w_dot() const { return w_dot_; };
 
-    Vector3 get_f_net() const { return _f_net; };
-    Vector3 get_t_net() const { return _t_net; };
+    Vector3 get_f_net() const { return f_net_; };
+    Vector3 get_t_net() const { return t_net_; };
 
-    double get_mass() const { return _mass; };
-    double get_d_ref() const { return _d_ref; };
-    double get_A_ref() const { return _A_ref; };
-    double get_Cna() const { return _Cna; };
-    double get_Cd() const { return _Cd; };
-    double get_nose_to_cg() const { return _nose_to_cg; };
-    double get_nose_to_cp() const { return _nose_to_cp; };
+    double get_mass() const { return mass_; };
+    double get_d_ref() const { return d_ref_; };
+    double get_A_ref() const { return A_ref_; };
+    double get_Cna() const { return Cna_; };
+    double get_Cd() const { return Cd_; };
+    double get_nose_to_cg() const { return nose_to_cg_; };
+    double get_nose_to_cp() const { return nose_to_cp_; };
 
-    Vector3 get_Cp_vect() const { return _Cp_vect; };
+    Vector3 get_Cp_vect() const { return Cp_vect_; };
 
     /************* Set parameters (all passed by reference) ***************/
-    void set_r_vect(Vector3& vector) { _r_vect = vector; };
-    void set_r_dot(Vector3& vector) { _r_dot = vector; };
-    void set_r_ddot(Vector3& vector) { _r_ddot = vector; };
+    void set_r_vect(Vector3& vector) { r_vect_ = vector; };
+    void set_r_dot(Vector3& vector) { r_dot_ = vector; };
+    void set_r_ddot(Vector3& vector) { r_ddot_ = vector; };
 
-    void set_q_ornt(Quaternion<double>& quatrn) { _q_ornt = quatrn; };
+    void set_q_ornt(Quaternion<double>& quatrn) { q_ornt_ = quatrn; };
 
     void set_I(double (&array)[9]) {
         for (int i = 0; i < 9; ++i) {
-            _I[i] = array[i];
+            I_[i] = array[i];
         }
     };
 
-    void set_w_vect(Vector3& vector) { _w_vect = vector; };
-    void set_w_dot(Vector3& vector) { _w_dot = vector; };
+    void set_w_vect(Vector3& vector) { w_vect_ = vector; };
+    void set_w_dot(Vector3& vector) { w_dot_ = vector; };
 
-    void set_f_net(Vector3& vector) { _f_net = vector; };
-    void set_t_net(Vector3& vector) { _t_net = vector; };
+    void set_f_net(Vector3& vector) { f_net_ = vector; };
+    void set_t_net(Vector3& vector) { t_net_ = vector; };
 
-    void set_mass(double& mass) { _mass = mass; };
-    void set_d_ref(double& d_ref) { _d_ref = d_ref; };
-    void set_A_ref(double& A_ref) { _A_ref = A_ref; };
-    void set_Cna(double& Cna) { _Cna = Cna; };
-    void set_Cd(double& Cd) { _Cd = Cd; };
+    void set_mass(double& mass) { mass_ = mass; };
+    void set_d_ref(double& d_ref) { d_ref_ = d_ref; };
+    void set_A_ref(double& A_ref) { A_ref_ = A_ref; };
+    void set_Cna(double& Cna) { Cna_ = Cna; };
+    void set_Cd(double& Cd) { Cd_ = Cd; };
     void set_nose_to_cg(double& nose_to_cg);
     void set_nose_to_cp(double& nose_to_cp);
 
@@ -113,32 +113,32 @@ class Rocket {
 
    private:
     // The following are in inertial frame
-    Vector3 _r_vect;  // r vector
-    Vector3 _r_dot;   // r-dot (velocity)
-    Vector3 _r_ddot;  // r-double-dot (acceleration)
-    Vector3 _w_vect;  // angular velocity (omega) vector
-    Vector3 _w_dot;   // angular acceleration vector
+    Vector3 r_vect_;  // r vector
+    Vector3 r_dot_;   // r-dot (velocity)
+    Vector3 r_ddot_;  // r-double-dot (acceleration)
+    Vector3 w_vect_;  // angular velocity (omega) vector
+    Vector3 w_dot_;   // angular acceleration vector
 
     // The following are in inertial frame
-    Vector3 _f_net;  // net force in Netwons
-    Vector3 _t_net;  // net torque in Newton*meters
+    Vector3 f_net_;  // net force in Netwons
+    Vector3 t_net_;  // net torque in Newton*meters
 
-    Quaternion<double> _q_ornt;  // inertial -> rocket frame quaternion
+    Quaternion<double> q_ornt_;  // inertial -> rocket frame quaternion
 
     // The following are in rocket frame
-    Vector3 _Cp_vect;  // CG to Cp vector
+    Vector3 Cp_vect_;  // CG to Cp vector
 
-    double _I[9];  // Rocket moment of inertia tensor
+    double I_[9];  // Rocket moment of inertia tensor
 
     // Default scalar parameters from OpenRocket
-    double _mass = 41.034;      // in Kg
-    double _d_ref = 0.0157;     // ref length in m
-    double _A_ref = 0.0194;     // ref area in m^2
-    double _Cna = 9.65;         // normal force coefficient derivative
+    double mass_ = 41.034;      // in Kg
+    double d_ref_ = 0.0157;     // ref length in m
+    double A_ref_ = 0.0194;     // ref area in m^2
+    double Cna_ = 9.65;         // normal force coefficient derivative
                                 // wrt angle-of-attack
-    double _Cd = 0.630;         // drag coefficient
-    double _nose_to_cg = 3.59;  // nosecone tip to CG distance in m
-    double _nose_to_cp = 4.03;  // nosecone tip to Cp distance in m
+    double Cd_ = 0.630;         // drag coefficient
+    double nose_to_cg_ = 3.59;  // nosecone tip to CG distance in m
+    double nose_to_cp_ = 4.03;  // nosecone tip to Cp distance in m
 };
 
 #endif

--- a/src/Rocket.h
+++ b/src/Rocket.h
@@ -2,12 +2,12 @@
  * @file 		Rocket.h
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		Rocket class definition 
+ * @brief 		Rocket class definition
  *
- * The rocket class encapsulates all physical quantities and parameters of the 
- * Rocket. The class also contains references to child objects representing 
+ * The rocket class encapsulates all physical quantities and parameters of the
+ * Rocket. The class also contains references to child objects representing
  * components like sensors and rocket motors along with mechanisms to extract
- * useful information about the rocket's state/trajectory. 
+ * useful information about the rocket's state/trajectory.
  *
  */
 
@@ -19,120 +19,126 @@
 #include <string>
 #include <vector>
 
-#include "quaternion.h"
 #include "Vector3.h"
+#include "quaternion.h"
 
 class Rocket {
-	public:
-		Rocket();
+   public:
+    Rocket();
 
-	    /****************** Get parameters by referece ************************/
-		void get_r_vect(Vector3& vector) const	{vector = _r_vect;};
-		void get_r_dot(Vector3& vector) const	{vector = _r_dot;};
-		void get_r_ddot(Vector3& vector) const	{vector = _r_ddot;};
+    /****************** Get parameters by referece ************************/
+    void get_r_vect(Vector3& vector) const { vector = _r_vect; };
+    void get_r_dot(Vector3& vector) const { vector = _r_dot; };
+    void get_r_ddot(Vector3& vector) const { vector = _r_ddot; };
 
-	    void get_q_ornt(Quaternion<double>& quatrn) const	{quatrn = _q_ornt;};
+    void get_q_ornt(Quaternion<double>& quatrn) const { quatrn = _q_ornt; };
 
-		void get_I(double (&array)[9]) const {for (int i=0;i<9;++i){array[i]=_I[i];}};
+    void get_I(double (&array)[9]) const {
+        for (int i = 0; i < 9; ++i) {
+            array[i] = _I[i];
+        }
+    };
 
-	    void get_w_vect(Vector3& vector) const	{vector = _w_vect;};
-	    void get_w_dot(Vector3& vector) const	{vector = _w_dot;};
+    void get_w_vect(Vector3& vector) const { vector = _w_vect; };
+    void get_w_dot(Vector3& vector) const { vector = _w_dot; };
 
-	    void get_f_net(Vector3& vector) const	{vector = _f_net;};
-	    void get_t_net(Vector3& vector) const	{vector = _t_net;};
+    void get_f_net(Vector3& vector) const { vector = _f_net; };
+    void get_t_net(Vector3& vector) const { vector = _t_net; };
 
-	    void get_mass(double& mass) const		{mass = _mass;};
-		void get_d_ref(double& d_ref) const		{d_ref = _d_ref;};
-		void get_A_ref(double& A_ref) const		{A_ref = _A_ref;};
-		void get_Cna(double& Cna) const			{Cna = _Cna;};
-	    void get_Cd(double& Cd) const			{Cd = _Cd;};
-		void get_nose_to_cg(double& nose_to_cg) const;
-		void get_nose_to_cp(double& nose_to_cp) const;
+    void get_mass(double& mass) const { mass = _mass; };
+    void get_d_ref(double& d_ref) const { d_ref = _d_ref; };
+    void get_A_ref(double& A_ref) const { A_ref = _A_ref; };
+    void get_Cna(double& Cna) const { Cna = _Cna; };
+    void get_Cd(double& Cd) const { Cd = _Cd; };
+    void get_nose_to_cg(double& nose_to_cg) const;
+    void get_nose_to_cp(double& nose_to_cp) const;
 
-		void get_Cp_vect(Vector3& vector) const;
+    void get_Cp_vect(Vector3& vector) const;
 
-		/************ Get parameters by value (return by value) ***************/
-	    Vector3 get_r_vect() const  {return _r_vect;};
-		Vector3 get_r_dot() const   {return _r_dot;};
-		Vector3 get_r_ddot() const  {return _r_ddot;};
+    /************ Get parameters by value (return by value) ***************/
+    Vector3 get_r_vect() const { return _r_vect; };
+    Vector3 get_r_dot() const { return _r_dot; };
+    Vector3 get_r_ddot() const { return _r_ddot; };
 
-	    Quaternion<double> get_q_ornt() const {return _q_ornt;};
+    Quaternion<double> get_q_ornt() const { return _q_ornt; };
 
-	    Vector3 get_w_vect() const  {return _w_vect;};
-	    Vector3 get_w_dot() const   {return _w_dot;};
+    Vector3 get_w_vect() const { return _w_vect; };
+    Vector3 get_w_dot() const { return _w_dot; };
 
-	    Vector3 get_f_net() const   {return _f_net;};
-	    Vector3 get_t_net() const   {return _t_net;};
+    Vector3 get_f_net() const { return _f_net; };
+    Vector3 get_t_net() const { return _t_net; };
 
-	    double get_mass() const     {return _mass;};
-		double get_d_ref() const	{return _d_ref;};
-		double get_A_ref() const	{return _A_ref;};
-		double get_Cna() const		{return _Cna;};
-	    double get_Cd() const       {return _Cd;};
-		double get_nose_to_cg() const	{return _nose_to_cg;};
-		double get_nose_to_cp() const	{return _nose_to_cp;};
+    double get_mass() const { return _mass; };
+    double get_d_ref() const { return _d_ref; };
+    double get_A_ref() const { return _A_ref; };
+    double get_Cna() const { return _Cna; };
+    double get_Cd() const { return _Cd; };
+    double get_nose_to_cg() const { return _nose_to_cg; };
+    double get_nose_to_cp() const { return _nose_to_cp; };
 
-		Vector3 get_Cp_vect() const	{return _Cp_vect;};
+    Vector3 get_Cp_vect() const { return _Cp_vect; };
 
-		/************* Set parameters (all passed by reference) ***************/
-		void set_r_vect(Vector3& vector)	{_r_vect = vector;};
-		void set_r_dot(Vector3& vector)		{_r_dot = vector;};
-		void set_r_ddot(Vector3& vector)	{_r_ddot = vector;};
+    /************* Set parameters (all passed by reference) ***************/
+    void set_r_vect(Vector3& vector) { _r_vect = vector; };
+    void set_r_dot(Vector3& vector) { _r_dot = vector; };
+    void set_r_ddot(Vector3& vector) { _r_ddot = vector; };
 
-		void set_q_ornt(Quaternion<double>& quatrn)	{_q_ornt = quatrn;};
+    void set_q_ornt(Quaternion<double>& quatrn) { _q_ornt = quatrn; };
 
-		void set_I(double (&array)[9]) {for (int i=0;i<9;++i){_I[i]=array[i];}};
+    void set_I(double (&array)[9]) {
+        for (int i = 0; i < 9; ++i) {
+            _I[i] = array[i];
+        }
+    };
 
-		void set_w_vect(Vector3& vector)	{_w_vect = vector;};
-		void set_w_dot(Vector3& vector)		{_w_dot = vector;};
+    void set_w_vect(Vector3& vector) { _w_vect = vector; };
+    void set_w_dot(Vector3& vector) { _w_dot = vector; };
 
-		void set_f_net(Vector3& vector)		{_f_net = vector;};
-		void set_t_net(Vector3& vector)		{_t_net = vector;};
+    void set_f_net(Vector3& vector) { _f_net = vector; };
+    void set_t_net(Vector3& vector) { _t_net = vector; };
 
-	    void set_mass(double& mass)			{_mass = mass;};
-		void set_d_ref(double& d_ref)		{_d_ref = d_ref;};
-		void set_A_ref(double& A_ref)		{_A_ref = A_ref;};
-		void set_Cna(double& Cna)			{_Cna = Cna;};
-		void set_Cd(double& Cd)				{_Cd = Cd;};
-		void set_nose_to_cg(double& nose_to_cg);
-		void set_nose_to_cp(double& nose_to_cp);
+    void set_mass(double& mass) { _mass = mass; };
+    void set_d_ref(double& d_ref) { _d_ref = d_ref; };
+    void set_A_ref(double& A_ref) { _A_ref = A_ref; };
+    void set_Cna(double& Cna) { _Cna = Cna; };
+    void set_Cd(double& Cd) { _Cd = Cd; };
+    void set_nose_to_cg(double& nose_to_cg);
+    void set_nose_to_cp(double& nose_to_cp);
 
-		// Converts vector from inertial frame to rocket reference frame
-		Vector3 i2r(Vector3 vector);
+    // Converts vector from inertial frame to rocket reference frame
+    Vector3 i2r(Vector3 vector);
 
-		// Converts vector from rocket frame to inertial reference frame
-		Vector3 r2i(Vector3 vector);
+    // Converts vector from rocket frame to inertial reference frame
+    Vector3 r2i(Vector3 vector);
 
-	private:
-		// The following are in inertial frame
-		Vector3 _r_vect;	// r vector
-		Vector3 _r_dot;		// r-dot (velocity)
-		Vector3 _r_ddot;	// r-double-dot (acceleration)
-		Vector3 _w_vect;	// angular velocity (omega) vector
-		Vector3 _w_dot;		// angular acceleration vector
+   private:
+    // The following are in inertial frame
+    Vector3 _r_vect;  // r vector
+    Vector3 _r_dot;   // r-dot (velocity)
+    Vector3 _r_ddot;  // r-double-dot (acceleration)
+    Vector3 _w_vect;  // angular velocity (omega) vector
+    Vector3 _w_dot;   // angular acceleration vector
 
-		// The following are in inertial frame
-		Vector3 _f_net;		// net force in Netwons
-		Vector3 _t_net;		// net torque in Newton*meters
+    // The following are in inertial frame
+    Vector3 _f_net;  // net force in Netwons
+    Vector3 _t_net;  // net torque in Newton*meters
 
-		Quaternion<double> _q_ornt;		// inertial -> rocket frame quaternion
+    Quaternion<double> _q_ornt;  // inertial -> rocket frame quaternion
 
-		// The following are in rocket frame
-		Vector3 _Cp_vect;	// CG to Cp vector
+    // The following are in rocket frame
+    Vector3 _Cp_vect;  // CG to Cp vector
 
-		double _I[9];		// Rocket moment of inertia tensor
+    double _I[9];  // Rocket moment of inertia tensor
 
-		// Default scalar parameters from OpenRocket
-		double _mass = 41.034;		// in Kg
-		double _d_ref = 0.0157;		// ref length in m
-		double _A_ref = 0.0194;		// ref area in m^2
-		double _Cna = 9.65;			// normal force coefficient derivative
-									// wrt angle-of-attack
-		double _Cd = 0.630;			// drag coefficient
-		double _nose_to_cg = 3.59;	// nosecone tip to CG distance in m
-		double _nose_to_cp = 4.03;	// nosecone tip to Cp distance in m
-
-
+    // Default scalar parameters from OpenRocket
+    double _mass = 41.034;      // in Kg
+    double _d_ref = 0.0157;     // ref length in m
+    double _A_ref = 0.0194;     // ref area in m^2
+    double _Cna = 9.65;         // normal force coefficient derivative
+                                // wrt angle-of-attack
+    double _Cd = 0.630;         // drag coefficient
+    double _nose_to_cg = 3.59;  // nosecone tip to CG distance in m
+    double _nose_to_cp = 4.03;  // nosecone tip to Cp distance in m
 };
 
 #endif

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -23,83 +23,83 @@
 Gyroscope::Gyroscope(std::string name, Rocket& rocket, double refresh_rate,
                      double noise_mean, double noise_stddev)
     : Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
-    _data = Vector3();
+    data_ = Vector3();
 }
 
 void Gyroscope::update_data(double tStep) {
-    if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
-        _rocket.get_w_vect(_data);
-        _rocket.i2r(_data);
-        _new_data = true;
+    if ((tStep - last_update_tStep_) >= (1 / refresh_rate_)) {
+        rocket_.get_w_vect(data_);
+        rocket_.i2r(data_);
+        new_data_ = true;
 
-        if (_inject_noise) {
-            _noise.randomize(_generator, _normal_dist);
-            _data += _noise;
+        if (inject_noise_) {
+            noise_.randomize(generator_, normal_dist_);
+            data_ += noise_;
         }
 
-        if (_inject_bias) {
-            _data += _bias;
+        if (inject_bias_) {
+            data_ += bias_;
         }
     }
 }
 
 void Gyroscope::get_data(Vector3& data) {
-    data = _data;
-    _new_data = false;
+    data = data_;
+    new_data_ = false;
 }
 
 Accelerometer::Accelerometer(std::string name, Rocket& rocket,
                              double refresh_rate, double noise_mean,
                              double noise_stddev)
     : Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
-    _data = Vector3();
+    data_ = Vector3();
 }
 
 void Accelerometer::update_data(double tStep) {
-    if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
-        _rocket.get_r_ddot(_data);
-        _rocket.i2r(_data);
-        _new_data = true;
+    if ((tStep - last_update_tStep_) >= (1 / refresh_rate_)) {
+        rocket_.get_r_ddot(data_);
+        rocket_.i2r(data_);
+        new_data_ = true;
 
-        if (_inject_noise) {
-            _noise.randomize(_generator, _normal_dist);
-            _data += _noise;
+        if (inject_noise_) {
+            noise_.randomize(generator_, normal_dist_);
+            data_ += noise_;
         }
 
-        if (_inject_bias) {
-            _data += _bias;
+        if (inject_bias_) {
+            data_ += bias_;
         }
     }
 }
 
 void Accelerometer::get_data(Vector3& data) {
-    data = _data;
-    _new_data = false;
+    data = data_;
+    new_data_ = false;
 }
 
 Barometer::Barometer(std::string name, Rocket& rocket, double refresh_rate,
                      double noise_mean, double noise_stddev)
     : Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
-    _data = _rocket.get_r_vect().x;
+    data_ = rocket_.get_r_vect().x;
 }
 
 void Barometer::update_data(double tStep) {
-    if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
-        _data = _rocket.get_r_vect().x;
-        _new_data = true;
+    if ((tStep - last_update_tStep_) >= (1 / refresh_rate_)) {
+        data_ = rocket_.get_r_vect().x;
+        new_data_ = true;
 
-        if (_inject_noise) {
-            _noise = _normal_dist(_generator);
-            _data += _noise;
+        if (inject_noise_) {
+            noise_ = normal_dist_(generator_);
+            data_ += noise_;
         }
 
-        if (_inject_bias) {
-            _data += _bias;
+        if (inject_bias_) {
+            data_ += bias_;
         }
     }
 }
 
 void Barometer::get_data(double& data) {
-    data = _data;
-    _new_data = false;
+    data = data_;
+    new_data_ = false;
 }

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -1,103 +1,105 @@
 /**
- * @file 		Sensor.cpp	
+ * @file 		Sensor.cpp
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		Member function implementations for Sensor classes	
+ * @brief 		Member function implementations for Sensor classes
  *
- * These Sensor classes encapsulate typical sensors found on Rocket avionics 
- * like accelerometers and gyroscopes. This is the mechanism through which 
- * the flight software being tested can obtain information of the simulated rocket.
- * The classes provide a modular a means of injecting noise and bias along with
- * other inaccuracies to make sensor measurements behave closer to real hardware
- * rather than simply providing ground truth. 
+ * These Sensor classes encapsulate typical sensors found on Rocket avionics
+ * like accelerometers and gyroscopes. This is the mechanism through which
+ * the flight software being tested can obtain information of the simulated
+ * rocket. The classes provide a modular a means of injecting noise and bias
+ * along with other inaccuracies to make sensor measurements behave closer to
+ * real hardware rather than simply providing ground truth.
  *
  */
 
-#include <vector>
-#include <string>
-
-#include "Rocket.h"
 #include "Sensor.h"
 
+#include <string>
+#include <vector>
+
+#include "Rocket.h"
+
 Gyroscope::Gyroscope(std::string name, Rocket& rocket, double refresh_rate,
-				     double noise_mean, double noise_stddev) :
-	Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
-	_data = Vector3();
+                     double noise_mean, double noise_stddev)
+    : Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
+    _data = Vector3();
 }
 
 void Gyroscope::update_data(double tStep) {
-	if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
-		_rocket.get_w_vect(_data);
-		_rocket.i2r(_data);
-		_new_data = true;
+    if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
+        _rocket.get_w_vect(_data);
+        _rocket.i2r(_data);
+        _new_data = true;
 
-		if (_inject_noise) {
-			_noise.randomize(_generator, _normal_dist);
-			_data += _noise;
-		}
+        if (_inject_noise) {
+            _noise.randomize(_generator, _normal_dist);
+            _data += _noise;
+        }
 
-		if (_inject_bias) {
-			_data += _bias;
-		}
-	}
+        if (_inject_bias) {
+            _data += _bias;
+        }
+    }
 }
 
 void Gyroscope::get_data(Vector3& data) {
-	data = _data;
-	_new_data = false;
+    data = _data;
+    _new_data = false;
 }
 
-Accelerometer::Accelerometer(std::string name, Rocket& rocket, double refresh_rate,
-							 double noise_mean, double noise_stddev) :
-	Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
-	_data = Vector3();
+Accelerometer::Accelerometer(std::string name, Rocket& rocket,
+                             double refresh_rate, double noise_mean,
+                             double noise_stddev)
+    : Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
+    _data = Vector3();
 }
 
 void Accelerometer::update_data(double tStep) {
-	if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
-		_rocket.get_r_ddot(_data);
-		_rocket.i2r(_data);
-		_new_data = true;
+    if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
+        _rocket.get_r_ddot(_data);
+        _rocket.i2r(_data);
+        _new_data = true;
 
-		if (_inject_noise) {
-			_noise.randomize(_generator, _normal_dist);
-			_data += _noise;
-		}
+        if (_inject_noise) {
+            _noise.randomize(_generator, _normal_dist);
+            _data += _noise;
+        }
 
-		if (_inject_bias) {
-			_data += _bias;
-		}
-	}
+        if (_inject_bias) {
+            _data += _bias;
+        }
+    }
 }
 
 void Accelerometer::get_data(Vector3& data) {
-	data = _data;
-	_new_data = false;
+    data = _data;
+    _new_data = false;
 }
 
 Barometer::Barometer(std::string name, Rocket& rocket, double refresh_rate,
-					 double noise_mean, double noise_stddev) :
-	Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
-	_data = _rocket.get_r_vect().x;	
+                     double noise_mean, double noise_stddev)
+    : Sensor(name, rocket, refresh_rate, noise_mean, noise_stddev) {
+    _data = _rocket.get_r_vect().x;
 }
 
 void Barometer::update_data(double tStep) {
-	if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
-		_data = _rocket.get_r_vect().x;
-		_new_data = true;
+    if ((tStep - _last_update_tStep) >= (1 / _refresh_rate)) {
+        _data = _rocket.get_r_vect().x;
+        _new_data = true;
 
-		if (_inject_noise) {
-			_noise = _normal_dist(_generator);
-			_data += _noise;
-		}
+        if (_inject_noise) {
+            _noise = _normal_dist(_generator);
+            _data += _noise;
+        }
 
-		if (_inject_bias) {
-			_data += _bias;
-		}
-	}
+        if (_inject_bias) {
+            _data += _bias;
+        }
+    }
 }
 
 void Barometer::get_data(double& data) {
-	data = _data;
-	_new_data = false;
+    data = _data;
+    _new_data = false;
 }

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -1,15 +1,15 @@
 /**
- * @file 		Sensor.h	
+ * @file 		Sensor.h
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		Class definition for Sensor classes 
+ * @brief 		Class definition for Sensor classes
  *
- * These Sensor classes encapsulate typical sensors found on Rocket avionics 
- * like accelerometers and gyroscopes. This is the mechanism through which 
- * the flight software being tested can obtain information of the simulated rocket.
- * The classes provide a modular a means of injecting noise and bias along with
- * other inaccuracies to make sensor measurements behave closer to real hardware
- * rather than simply providing ground truth. 
+ * These Sensor classes encapsulate typical sensors found on Rocket avionics
+ * like accelerometers and gyroscopes. This is the mechanism through which
+ * the flight software being tested can obtain information of the simulated
+ * rocket. The classes provide a modular a means of injecting noise and bias
+ * along with other inaccuracies to make sensor measurements behave closer to
+ * real hardware rather than simply providing ground truth.
  *
  */
 
@@ -18,103 +18,105 @@
 #ifndef _SENSOR_H_
 #define _SENSOR_H_
 
+#include <random>
 #include <string>
 #include <vector>
-#include <random>
 
 #include "Rocket.h"
 #include "Vector3.h"
 
 class Sensor {
-	public:
-		Sensor(std::string name, Rocket& rocket, double refresh_rate,
-			   double noise_mean=0.0f, double noise_stddev=0.1f) :
-														_name(name),
-														_rocket(rocket),
-														_refresh_rate(refresh_rate),
-														_last_update_tStep(0),
-														_normal_dist(noise_mean, noise_stddev) {};
+   public:
+    Sensor(std::string name, Rocket& rocket, double refresh_rate,
+           double noise_mean = 0.0f, double noise_stddev = 0.1f)
+        : _name(name),
+          _rocket(rocket),
+          _refresh_rate(refresh_rate),
+          _last_update_tStep(0),
+          _normal_dist(noise_mean, noise_stddev){};
 
-		bool is_new_data() {return _new_data;};
-		std::string get_name() {return _name;};
+    bool is_new_data() { return _new_data; };
+    std::string get_name() { return _name; };
 
-		virtual void update_data(double tStep) = 0;
-		virtual void get_data(Vector3& data) = 0;
-		// virtual void get_data(double& data) = 0;
+    virtual void update_data(double tStep) = 0;
+    virtual void get_data(Vector3& data) = 0;
+    // virtual void get_data(double& data) = 0;
 
-		// Noise/bias injection control
-		void enable_noise_injection() 	{_inject_noise = true;};
-		void disable_noise_injection() 	{_inject_noise = false;};
-		void enable_bias_injection() 	{_inject_bias = true;};
-		void disable_bias_injection() 	{_inject_bias = false;};
+    // Noise/bias injection control
+    void enable_noise_injection() { _inject_noise = true; };
+    void disable_noise_injection() { _inject_noise = false; };
+    void enable_bias_injection() { _inject_bias = true; };
+    void disable_bias_injection() { _inject_bias = false; };
 
-	protected:
+   protected:
+    std::string _name;
 
-		std::string _name;
-		
-		Rocket& _rocket;
+    Rocket& _rocket;
 
-		double _refresh_rate;
-		double _last_update_tStep;
-		bool _new_data;
+    double _refresh_rate;
+    double _last_update_tStep;
+    bool _new_data;
 
-		// Normal distribution noise generation
-		std::default_random_engine _generator;
-		std::normal_distribution<double> _normal_dist;
-		bool _inject_bias = false; 			// Whether to inject constant bias to measurement
-		bool _inject_noise = false; 		// Whether to inject random noise to measurement
+    // Normal distribution noise generation
+    std::default_random_engine _generator;
+    std::normal_distribution<double> _normal_dist;
+    bool _inject_bias =
+        false;  // Whether to inject constant bias to measurement
+    bool _inject_noise =
+        false;  // Whether to inject random noise to measurement
 };
 
 class Gyroscope : public Sensor {
-	public:
-		Gyroscope(std::string name, Rocket& rocket, double refresh_rate,
-				  double noise_mean=0.0f, double noise_stddev=0.1f);
-		void update_data(double tStep);
-		void get_data(Vector3& data);
+   public:
+    Gyroscope(std::string name, Rocket& rocket, double refresh_rate,
+              double noise_mean = 0.0f, double noise_stddev = 0.1f);
+    void update_data(double tStep);
+    void get_data(Vector3& data);
 
-		void set_constant_bias(Vector3 bias) {_bias = bias;};
+    void set_constant_bias(Vector3 bias) { _bias = bias; };
 
-	private:
-		Vector3 _data; 		// The sensor's current reading
+   private:
+    Vector3 _data;  // The sensor's current reading
 
-		Vector3 _noise; 	// Noise vector to be added to measurement
-				
-		Vector3 _bias; 		// Constant bias vector to be added to measurement	
+    Vector3 _noise;  // Noise vector to be added to measurement
+
+    Vector3 _bias;  // Constant bias vector to be added to measurement
 };
 
 class Accelerometer : public Sensor {
-	public:
-		Accelerometer(std::string name, Rocket& rocket, double refresh_rate,
-					  double noise_mean=0.0f, double noise_stddev=0.1f);
-		void update_data(double tStep);
-		void get_data(Vector3& data);
+   public:
+    Accelerometer(std::string name, Rocket& rocket, double refresh_rate,
+                  double noise_mean = 0.0f, double noise_stddev = 0.1f);
+    void update_data(double tStep);
+    void get_data(Vector3& data);
 
-		void set_constant_bias(Vector3 bias) {_bias = bias;};
+    void set_constant_bias(Vector3 bias) { _bias = bias; };
 
- 	private:
-		Vector3 _data; 		// The sensor's current reading
+   private:
+    Vector3 _data;  // The sensor's current reading
 
-		Vector3 _noise; 	// Noise vector to be added to measurement
+    Vector3 _noise;  // Noise vector to be added to measurement
 
-		Vector3 _bias; 		// Constant bias vector to be added to measurement	
+    Vector3 _bias;  // Constant bias vector to be added to measurement
 };
 
-// TODO: Implement functions for both altitude and pressure measurements (and specify units)
+// TODO: Implement functions for both altitude and pressure measurements (and
+// specify units)
 class Barometer : public Sensor {
-	public:
-		Barometer(std::string name, Rocket& rocket, double refresh_rate,
-				  double noise_mean=0.0f, double noise_stddev=0.1f);
-		void update_data(double tStep);
-		void get_data(double& data);
+   public:
+    Barometer(std::string name, Rocket& rocket, double refresh_rate,
+              double noise_mean = 0.0f, double noise_stddev = 0.1f);
+    void update_data(double tStep);
+    void get_data(double& data);
 
-		void set_constant_bias(double bias) {_bias = bias;};
-	
-	private:
-		double _data; 		// The sensor's current reading
+    void set_constant_bias(double bias) { _bias = bias; };
 
-		double _noise; 		// Noise value to be added to measurement
+   private:
+    double _data;  // The sensor's current reading
 
-		double _bias; 		// Constant bias value to be added to measurement	
+    double _noise;  // Noise value to be added to measurement
+
+    double _bias;  // Constant bias value to be added to measurement
 };
 
 #endif

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -29,41 +29,41 @@ class Sensor {
    public:
     Sensor(std::string name, Rocket& rocket, double refresh_rate,
            double noise_mean = 0.0f, double noise_stddev = 0.1f)
-        : _name(name),
-          _rocket(rocket),
-          _refresh_rate(refresh_rate),
-          _last_update_tStep(0),
-          _normal_dist(noise_mean, noise_stddev){};
+        : name_(name),
+          rocket_(rocket),
+          refresh_rate_(refresh_rate),
+          last_update_tStep_(0),
+          normal_dist_(noise_mean, noise_stddev){};
 
-    bool is_new_data() { return _new_data; };
-    std::string get_name() { return _name; };
+    bool is_new_data() { return new_data_; };
+    std::string get_name() { return name_; };
 
     virtual void update_data(double tStep) = 0;
     virtual void get_data(Vector3& data) = 0;
     // virtual void get_data(double& data) = 0;
 
     // Noise/bias injection control
-    void enable_noise_injection() { _inject_noise = true; };
-    void disable_noise_injection() { _inject_noise = false; };
-    void enable_bias_injection() { _inject_bias = true; };
-    void disable_bias_injection() { _inject_bias = false; };
+    void enable_noise_injection() { inject_noise_ = true; };
+    void disable_noise_injection() { inject_noise_ = false; };
+    void enable_bias_injection() { inject_bias_ = true; };
+    void disable_bias_injection() { inject_bias_ = false; };
 
    protected:
-    std::string _name;
+    std::string name_;
 
-    Rocket& _rocket;
+    Rocket& rocket_;
 
-    double _refresh_rate;
-    double _last_update_tStep;
-    bool _new_data;
+    double refresh_rate_;
+    double last_update_tStep_;
+    bool new_data_;
 
     // Normal distribution noise generation
-    std::default_random_engine _generator;
-    std::normal_distribution<double> _normal_dist;
-    bool _inject_bias =
-        false;  // Whether to inject constant bias to measurement
-    bool _inject_noise =
-        false;  // Whether to inject random noise to measurement
+    std::default_random_engine generator_;
+    std::normal_distribution<double> normal_dist_;
+
+    // Whether to inject constant bias or gaussian noise to measurement
+    bool inject_bias_ = false;
+    bool inject_noise_ = false;
 };
 
 class Gyroscope : public Sensor {
@@ -73,14 +73,14 @@ class Gyroscope : public Sensor {
     void update_data(double tStep);
     void get_data(Vector3& data);
 
-    void set_constant_bias(Vector3 bias) { _bias = bias; };
+    void set_constant_bias(Vector3 bias) { bias_ = bias; };
 
    private:
-    Vector3 _data;  // The sensor's current reading
+    Vector3 data_;  // The sensor's current reading
 
-    Vector3 _noise;  // Noise vector to be added to measurement
+    Vector3 noise_;  // Noise vector to be added to measurement
 
-    Vector3 _bias;  // Constant bias vector to be added to measurement
+    Vector3 bias_;  // Constant bias vector to be added to measurement
 };
 
 class Accelerometer : public Sensor {
@@ -90,14 +90,14 @@ class Accelerometer : public Sensor {
     void update_data(double tStep);
     void get_data(Vector3& data);
 
-    void set_constant_bias(Vector3 bias) { _bias = bias; };
+    void set_constant_bias(Vector3 bias) { bias_ = bias; };
 
    private:
-    Vector3 _data;  // The sensor's current reading
+    Vector3 data_;  // The sensor's current reading
 
-    Vector3 _noise;  // Noise vector to be added to measurement
+    Vector3 noise_;  // Noise vector to be added to measurement
 
-    Vector3 _bias;  // Constant bias vector to be added to measurement
+    Vector3 bias_;  // Constant bias vector to be added to measurement
 };
 
 // TODO: Implement functions for both altitude and pressure measurements (and
@@ -109,14 +109,14 @@ class Barometer : public Sensor {
     void update_data(double tStep);
     void get_data(double& data);
 
-    void set_constant_bias(double bias) { _bias = bias; };
+    void set_constant_bias(double bias) { bias_ = bias; };
 
    private:
-    double _data;  // The sensor's current reading
+    double data_;  // The sensor's current reading
 
-    double _noise;  // Noise value to be added to measurement
+    double noise_;  // Noise value to be added to measurement
 
-    double _bias;  // Constant bias value to be added to measurement
+    double bias_;  // Constant bias value to be added to measurement
 };
 
 #endif

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -2,130 +2,132 @@
  * @file 		Simulation.cpp
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		Simulation class member function implementations 
+ * @brief 		Simulation class member function implementations
  *
  * The Simulation class encapsulates meta information about the simulation.
  * It also contains references to relevant components of the simulation to
  * be performed, like a PhysicsEngine object and a Rocket object.
  *
  * In the hierearchy of SILSIM, the Simulation class sits at the top of the
- * tree and "governs" the simulation itself. 
+ * tree and "governs" the simulation itself.
  *
  */
 
-#include <iostream>
-#include <string>
-#include <fstream>
+#include "Simulation.h"
+
 #include <math.h>
 
-#include "Simulation.h"
+#include <fstream>
+#include <iostream>
+#include <string>
+
 #include "PhysicsEngine.h"
-#include "Rocket.h"
 #include "Propulsion.h"
+#include "Rocket.h"
 #include "Sensor.h"
-#include "quaternion.h"
 #include "Vector3.h"
+#include "quaternion.h"
 
 #define RAD2DEG (180.0 / 3.14159265);
 
 // #define SIM_DEBUG
 
 void Simulation::run(int steps) {
+    std::ofstream dataFile(_filename);
 
-	std::ofstream dataFile(_filename);
+    Vector3 r_vect;
+    Vector3 r_dot;
+    Vector3 r_ddot;
+    Vector3 f_net;
+    Vector3 w_net;
 
-	Vector3 r_vect;
-	Vector3 r_dot;
-	Vector3 r_ddot;
-	Vector3 f_net;
-	Vector3 w_net;
+    Quaternion<double> q_ornt;
 
-	Quaternion<double> q_ornt;
+    double roll, pitch, yaw;
 
-	double roll,pitch,yaw;
+    _motor.ignite(_tStamp);
 
-	_motor.ignite(_tStamp);
+    for (int iter = 0; iter < steps; ++iter) {
+        _rocket.get_r_vect(r_vect);
+        _rocket.get_r_dot(r_dot);
+        _rocket.get_r_ddot(r_ddot);
+        _rocket.get_f_net(f_net);
+        _rocket.get_w_vect(w_net);
+        _rocket.get_q_ornt(q_ornt);
 
-	for (int iter = 0; iter < steps; ++iter) {
+        float s = q_ornt.Gets();
+        float x = q_ornt.Getx();
+        float y = q_ornt.Gety();
+        float z = q_ornt.Getz();
 
-		_rocket.get_r_vect(r_vect);
-		_rocket.get_r_dot(r_dot);
-		_rocket.get_r_ddot(r_ddot);
-		_rocket.get_f_net(f_net);
-		_rocket.get_w_vect(w_net);
-		_rocket.get_q_ornt(q_ornt);
-
-		float s = q_ornt.Gets();
-		float x = q_ornt.Getx();
-		float y = q_ornt.Gety();
-		float z = q_ornt.Getz();
-
-		// eqns from https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
-		yaw  = atan2(2.0*(s*x + z*y), 1.0 - 2.0*(x*x + y*y)) * RAD2DEG;
-		pitch = asin(2.0*(s*y - z*x)) * RAD2DEG;
-		roll = atan2(2.0*(s*z + x*y), -1.0 + 2.0*(s*s + x*x)) * RAD2DEG;
-
+        // eqns from
+        // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+        yaw =
+            atan2(2.0 * (s * x + z * y), 1.0 - 2.0 * (x * x + y * y)) * RAD2DEG;
+        pitch = asin(2.0 * (s * y - z * x)) * RAD2DEG;
+        roll = atan2(2.0 * (s * z + x * y), -1.0 + 2.0 * (s * s + x * x)) *
+               RAD2DEG;
 
 #ifdef SIM_DEBUG
-		double alpha = acos(_rocket.i2r(r_dot).z / (r_dot.magnitude()));
-		printf("Timestamp: %f\n", _tStamp);
-		printf("\tR-Vector: <%f, %f, %f>", r_vect.x, r_vect.y, r_vect.z);
-		printf("\tVelocity: <%f, %f, %f>", r_dot.x, r_dot.y, r_dot.z);
-		printf("\tAccel: <%f, %f, %f>", r_ddot.x, r_ddot.y, r_ddot.z);
-		printf("\tF-Net: <%f, %f, %f>", f_net.x, f_net.y, f_net.z);
-		printf("\tW-Net: <%f, %f, %f>\n", w_net.x, w_net.y, w_net.z);
-		printf("ROLL: %f \tPITCH: %f \tYAW: %f  [deg]", roll, pitch, yaw);
-		printf("\nalphaSIM: %f  [deg]\n\n", alpha*RAD2DEG);
+        double alpha = acos(_rocket.i2r(r_dot).z / (r_dot.magnitude()));
+        printf("Timestamp: %f\n", _tStamp);
+        printf("\tR-Vector: <%f, %f, %f>", r_vect.x, r_vect.y, r_vect.z);
+        printf("\tVelocity: <%f, %f, %f>", r_dot.x, r_dot.y, r_dot.z);
+        printf("\tAccel: <%f, %f, %f>", r_ddot.x, r_ddot.y, r_ddot.z);
+        printf("\tF-Net: <%f, %f, %f>", f_net.x, f_net.y, f_net.z);
+        printf("\tW-Net: <%f, %f, %f>\n", w_net.x, w_net.y, w_net.z);
+        printf("ROLL: %f \tPITCH: %f \tYAW: %f  [deg]", roll, pitch, yaw);
+        printf("\nalphaSIM: %f  [deg]\n\n", alpha * RAD2DEG);
 #endif
 
-		Vector3 rocket_axis(0, 0, 1);
-		rocket_axis = _rocket.r2i(rocket_axis);
+        Vector3 rocket_axis(0, 0, 1);
+        rocket_axis = _rocket.r2i(rocket_axis);
 
-		_engine.march_step(_tStamp, _tStep);
+        _engine.march_step(_tStamp, _tStep);
 
-		update_sensors();
+        update_sensors();
 
-		dataFile << _tStamp << ",";
-		dataFile << r_vect.x << "," << r_vect.y << "," << r_vect.z << ",";
-		dataFile << r_dot.x << "," << r_dot.y << "," << r_dot.z << ",";
-		dataFile << r_ddot.x << "," << r_ddot.y << "," << r_ddot.z << ",";
-		dataFile << f_net.x << "," << f_net.y << "," << f_net.z << ",";
-		dataFile << s << "," << x << "," << y << "," << z  << ",";
-		dataFile << roll << "," << pitch << "," << yaw << ",";
-		dataFile << rocket_axis.x << "," << rocket_axis.y << "," << rocket_axis.z << ",";
-		
-		Vector3 sensor_data;
-		_sensors[0]->get_data(sensor_data);
-		dataFile << sensor_data.x << "," << sensor_data.y << "," << sensor_data.z;
+        dataFile << _tStamp << ",";
+        dataFile << r_vect.x << "," << r_vect.y << "," << r_vect.z << ",";
+        dataFile << r_dot.x << "," << r_dot.y << "," << r_dot.z << ",";
+        dataFile << r_ddot.x << "," << r_ddot.y << "," << r_ddot.z << ",";
+        dataFile << f_net.x << "," << f_net.y << "," << f_net.z << ",";
+        dataFile << s << "," << x << "," << y << "," << z << ",";
+        dataFile << roll << "," << pitch << "," << yaw << ",";
+        dataFile << rocket_axis.x << "," << rocket_axis.y << ","
+                 << rocket_axis.z << ",";
 
-		dataFile << "\n";
+        Vector3 sensor_data;
+        _sensors[0]->get_data(sensor_data);
+        dataFile << sensor_data.x << "," << sensor_data.y << ","
+                 << sensor_data.z;
 
-		_tStamp += _tStep;
+        dataFile << "\n";
 
-		if (r_dot.z < -3.0) {
-			break;
-		}
-	}
+        _tStamp += _tStep;
 
-	dataFile.close();
+        if (r_dot.z < -3.0) {
+            break;
+        }
+    }
+
+    dataFile.close();
 }
 
 /**
- * @brief Adds a new sensor on the rocket to the simulation 
+ * @brief Adds a new sensor on the rocket to the simulation
  *
  * @param sensor A pointer to the new Sensor object to be added
  */
-void Simulation::add_sensor(Sensor* sensor) {
-		_sensors.push_back(sensor);
-}
+void Simulation::add_sensor(Sensor* sensor) { _sensors.push_back(sensor); }
 
 /**
- * @brief Updates all sensors' internal data 
+ * @brief Updates all sensors' internal data
  *
  */
 void Simulation::update_sensors() {
-		for (std::vector<Sensor*>::iterator it = _sensors.begin(); it != _sensors.end(); ++it) {
-				(*it)->update_data(_tStamp);
-		}
-
+    for (std::vector<Sensor*>::iterator it = _sensors.begin();
+         it != _sensors.end(); ++it) {
+        (*it)->update_data(_tStamp);
+    }
 }

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -33,7 +33,7 @@
 // #define SIM_DEBUG
 
 void Simulation::run(int steps) {
-    std::ofstream dataFile(_filename);
+    std::ofstream dataFile(filename_);
 
     Vector3 r_vect;
     Vector3 r_dot;
@@ -45,15 +45,15 @@ void Simulation::run(int steps) {
 
     double roll, pitch, yaw;
 
-    _motor.ignite(_tStamp);
+    motor_.ignite(tStamp_);
 
     for (int iter = 0; iter < steps; ++iter) {
-        _rocket.get_r_vect(r_vect);
-        _rocket.get_r_dot(r_dot);
-        _rocket.get_r_ddot(r_ddot);
-        _rocket.get_f_net(f_net);
-        _rocket.get_w_vect(w_net);
-        _rocket.get_q_ornt(q_ornt);
+        rocket_.get_r_vect(r_vect);
+        rocket_.get_r_dot(r_dot);
+        rocket_.get_r_ddot(r_ddot);
+        rocket_.get_f_net(f_net);
+        rocket_.get_w_vect(w_net);
+        rocket_.get_q_ornt(q_ornt);
 
         float s = q_ornt.Gets();
         float x = q_ornt.Getx();
@@ -69,8 +69,8 @@ void Simulation::run(int steps) {
                RAD2DEG;
 
 #ifdef SIM_DEBUG
-        double alpha = acos(_rocket.i2r(r_dot).z / (r_dot.magnitude()));
-        printf("Timestamp: %f\n", _tStamp);
+        double alpha = acos(rocket_.i2r(r_dot).z / (r_dot.magnitude()));
+        printf("Timestamp: %f\n", tStamp_);
         printf("\tR-Vector: <%f, %f, %f>", r_vect.x, r_vect.y, r_vect.z);
         printf("\tVelocity: <%f, %f, %f>", r_dot.x, r_dot.y, r_dot.z);
         printf("\tAccel: <%f, %f, %f>", r_ddot.x, r_ddot.y, r_ddot.z);
@@ -81,13 +81,13 @@ void Simulation::run(int steps) {
 #endif
 
         Vector3 rocket_axis(0, 0, 1);
-        rocket_axis = _rocket.r2i(rocket_axis);
+        rocket_axis = rocket_.r2i(rocket_axis);
 
-        _engine.march_step(_tStamp, _tStep);
+        engine_.march_step(tStamp_, tStep_);
 
         update_sensors();
 
-        dataFile << _tStamp << ",";
+        dataFile << tStamp_ << ",";
         dataFile << r_vect.x << "," << r_vect.y << "," << r_vect.z << ",";
         dataFile << r_dot.x << "," << r_dot.y << "," << r_dot.z << ",";
         dataFile << r_ddot.x << "," << r_ddot.y << "," << r_ddot.z << ",";
@@ -98,13 +98,13 @@ void Simulation::run(int steps) {
                  << rocket_axis.z << ",";
 
         Vector3 sensor_data;
-        _sensors[0]->get_data(sensor_data);
+        sensors_[0]->get_data(sensor_data);
         dataFile << sensor_data.x << "," << sensor_data.y << ","
                  << sensor_data.z;
 
         dataFile << "\n";
 
-        _tStamp += _tStep;
+        tStamp_ += tStep_;
 
         if (r_dot.z < -3.0) {
             break;
@@ -119,15 +119,15 @@ void Simulation::run(int steps) {
  *
  * @param sensor A pointer to the new Sensor object to be added
  */
-void Simulation::add_sensor(Sensor* sensor) { _sensors.push_back(sensor); }
+void Simulation::add_sensor(Sensor* sensor) { sensors_.push_back(sensor); }
 
 /**
  * @brief Updates all sensors' internal data
  *
  */
 void Simulation::update_sensors() {
-    for (std::vector<Sensor*>::iterator it = _sensors.begin();
-         it != _sensors.end(); ++it) {
-        (*it)->update_data(_tStamp);
+    for (std::vector<Sensor*>::iterator it = sensors_.begin();
+         it != sensors_.end(); ++it) {
+        (*it)->update_data(tStamp_);
     }
 }

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -34,12 +34,12 @@ class Simulation {
                SolidMotor& motor, std::string filename
                // std::vector<Sensor&>& sensors
                )
-        : _tStamp(0),
-          _tStep(tStep),
-          _engine(engine),
-          _rocket(rocket),
-          _motor(motor),
-          _filename(filename){};
+        : tStamp_(0),
+          tStep_(tStep),
+          engine_(engine),
+          rocket_(rocket),
+          motor_(motor),
+          filename_(filename){};
 
     void run(int steps);
 
@@ -48,18 +48,18 @@ class Simulation {
     void update_sensors();
 
    private:
-    double _tStamp;
-    double _tStep;
+    double tStamp_;
+    double tStep_;
 
-    PhysicsEngine& _engine;
+    PhysicsEngine& engine_;
 
-    Rocket& _rocket;
-    SolidMotor& _motor;
+    Rocket& rocket_;
+    SolidMotor& motor_;
 
     // Sensors
-    std::vector<Sensor*> _sensors;  // array of sensors on the rocket
+    std::vector<Sensor*> sensors_;  // array of sensors on the rocket
 
-    std::string _filename;
+    std::string filename_;
 };
 
 #endif

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -2,15 +2,15 @@
  * @file 		Simulation.h
  * @authors 	Ayberk Yaraneri
  *
- * @brief 		Simulation class definition 
+ * @brief 		Simulation class definition
  *
  * The Simulation class encapsulates meta information about the simulation.
  * The class contains references to relevant components of the simulation to
- * be performed, like a PhysicsEngine object and a Rocket object. It also 
+ * be performed, like a PhysicsEngine object and a Rocket object. It also
  * incorporates mechanisms for data logging and diagnostics/debugging.
  *
  * In the hierearchy of SILSIM, the Simulation class sits at the top of the
- * tree and "governs" the simulation itself. 
+ * tree and "governs" the simulation itself.
  *
  */
 
@@ -19,48 +19,47 @@
 #ifndef _SIMULATION_H_
 #define _SIMULATION_H_
 
-#include <string>
 #include <fstream>
+#include <string>
 
 #include "PhysicsEngine.h"
-#include "Rocket.h"
 #include "Propulsion.h"
+#include "Rocket.h"
 #include "Sensor.h"
 #include "quaternion.h"
 
 class Simulation {
-public:
+   public:
+    Simulation(double tStep, PhysicsEngine& engine, Rocket& rocket,
+               SolidMotor& motor, std::string filename
+               // std::vector<Sensor&>& sensors
+               )
+        : _tStamp(0),
+          _tStep(tStep),
+          _engine(engine),
+          _rocket(rocket),
+          _motor(motor),
+          _filename(filename){};
 
-	Simulation(
-		double tStep,
-		PhysicsEngine& engine,
-		Rocket& rocket,
-		SolidMotor& motor,
-		std::string filename
-		// std::vector<Sensor&>& sensors
-	) :	_tStamp(0), _tStep(tStep), _engine(engine), _rocket(rocket),
-	 	_motor(motor), _filename(filename) {};
+    void run(int steps);
 
-	void run(int steps);
+    /************************* Sensor interface ***************************/
+    void add_sensor(Sensor* sensor);
+    void update_sensors();
 
-	/************************* Sensor interface ***************************/
-	void add_sensor(Sensor* sensor);
-	void update_sensors();
+   private:
+    double _tStamp;
+    double _tStep;
 
+    PhysicsEngine& _engine;
 
-private:
-	double _tStamp;
-	double _tStep;
+    Rocket& _rocket;
+    SolidMotor& _motor;
 
-	PhysicsEngine& _engine;
+    // Sensors
+    std::vector<Sensor*> _sensors;  // array of sensors on the rocket
 
-	Rocket& _rocket;
-	SolidMotor& _motor;
-	
-	// Sensors
-	std::vector<Sensor*> _sensors; 	// array of sensors on the rocket
-
-	std::string _filename;
+    std::string _filename;
 };
 
 #endif


### PR DESCRIPTION
- Ran clang-format on all the source code
- Changed class member variables to have trailing underscores: from '_rocket' to 'rocket_' This matches Google style guide
- Added a missing comment