### PR TITLE
[AV-346] Fix quaternion update math

### DIFF
--- a/includes/PhysicsEngine.h
+++ b/includes/PhysicsEngine.h
@@ -43,6 +43,9 @@ class ForwardEuler : public PhysicsEngine {
     void march_step(double tStamp, double tStep) override;
 
    private:
+    Quaternion<double> update_quaternion(Quaternion<double> q_ornt,
+                                         Vector3 omega_if, double tStep);
+
     std::shared_ptr<spdlog::logger> euler_logger;
 };
 

--- a/includes/PhysicsEngine.h
+++ b/includes/PhysicsEngine.h
@@ -44,7 +44,7 @@ class ForwardEuler : public PhysicsEngine {
 
    private:
     Quaternion<double> update_quaternion(Quaternion<double> q_ornt,
-                                         Vector3 omega_if, double tStep);
+                                         Vector3 omega_if, double tStep) const;
 
     std::shared_ptr<spdlog::logger> euler_logger;
 };

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -186,10 +186,12 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
  * @param q_ornt    The current orientation quaternion
  * @param omega_if  The angular velocity vector in inertial frame
  * @param tStep     Simulation time step size
+ *
+ * @return Quaternion<double> Updated quaterion with the applied rotation
  */
 Quaternion<double> ForwardEuler::update_quaternion(Quaternion<double> q_ornt,
                                                    Vector3 omega_if,
-                                                   double tStep) {
+                                                   double tStep) const {
     // Create a quaternion from angular velocity
     Quaternion<double> q_omega{0, omega_if.x, omega_if.y, omega_if.z};
 

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -132,9 +132,7 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
     r_dot_if += r_ddot_if * tStep;
     r_ddot_if = f_net_if / mass;
 
-    // magnitudes below this threshold approach division-by-zero 
-    if (w_vect_if.magnitude() > 1e-6)
-        q_ornt = update_quaternion(q_ornt, w_vect_if, tStep);
+    q_ornt = update_quaternion(q_ornt, w_vect_if, tStep);
 
     w_vect_if += w_dot_if * tStep;
 


### PR DESCRIPTION
The implementation of updating the rocket's orientation quaternion was wrong and didn't account for the simulation timestep size.

This PR fixes the implementation and abstracts it to a helper member function.