### PR TITLE
Bug/drag force direction

### DIFF
--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -106,7 +106,7 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
 
         double f_D_mag = c_D * 0.5 * Atmosphere::get_density(r_vect_if.z) *
                          v_rf.magnitude2() * A_ref;
-        Vector3 f_D_rf(0, 0, -f_D_mag);
+        Vector3 f_D_rf(0, 0, std::copysign(f_D_mag, -v_rf.z));
 
         f_aero_rf = f_N_rf + f_D_rf;
         t_aero_rf = Cp_vect_rf.cross(f_aero_rf);

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -106,7 +106,7 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
 
         double f_D_mag = c_D * 0.5 * Atmosphere::get_density(r_vect_if.z) *
                          v_rf.magnitude2() * A_ref;
-        //make drag force apply in the opposite direction to rocket travel
+        // make drag force apply in the opposite direction to rocket travel
         Vector3 f_D_rf(0, 0, std::copysign(f_D_mag, -v_rf.z));
 
         f_aero_rf = f_N_rf + f_D_rf;

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -106,6 +106,7 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
 
         double f_D_mag = c_D * 0.5 * Atmosphere::get_density(r_vect_if.z) *
                          v_rf.magnitude2() * A_ref;
+        //make drag force apply in the opposite direction to rocket travel
         Vector3 f_D_rf(0, 0, std::copysign(f_D_mag, -v_rf.z));
 
         f_aero_rf = f_N_rf + f_D_rf;


### PR DESCRIPTION
Fix a bug where drag force would always be applied backwards in rocket frame instead of in in the opposite direction of movement in rocket frame.