### PR TITLE
AV 273 Geodesic Earth

### DIFF
--- a/includes/PhysicsEngine.h
+++ b/includes/PhysicsEngine.h
@@ -67,6 +67,8 @@ class RungeKutta : public PhysicsEngine {
     Vector3d calc_net_force(double tStamp, Vector3d pos_if, Vector3d vel_if);
     Vector3d calc_net_torque(Vector3d vel_if, Vector3d pos_if);
     RungeKuttaState calc_state(double tStamp, double tStep, RungeKuttaState k);
+    Vector3d i2ecef(Vector3d pos_if);
+    Vector3d ecef2geod(Vector3d ecef);
 };
 
 #endif

--- a/includes/PhysicsEngine.h
+++ b/includes/PhysicsEngine.h
@@ -14,6 +14,7 @@
 
 #ifndef _PHYSICS_ENGINE_H_
 #define _PHYSICS_ENGINE_H_
+#define _USE_MATH_DEFINES
 
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>

--- a/includes/PhysicsEngine.h
+++ b/includes/PhysicsEngine.h
@@ -33,7 +33,7 @@ class PhysicsEngine {
     virtual void march_step(double tStamp, double tStep) = 0;
 
    protected:
-    Quaterniond update_quaternion(Quaterniond q_ornt, Vector3d omega_if,
+    Quaterniond update_quaternion(Quaterniond q_ornt, Vector3d omega_enu,
                                   double tStep) const;
     Rocket& rocket_;
     SolidMotor& motor_;
@@ -65,10 +65,10 @@ class RungeKutta : public PhysicsEngine {
         Vector3d ang_accel;
     };
 
-    Vector3d calc_net_force(double tStamp, Vector3d pos_if, Vector3d vel_if);
-    Vector3d calc_net_torque(Vector3d vel_if, Vector3d pos_if);
+    Vector3d calc_net_force(double tStamp, Vector3d pos_enu, Vector3d vel_enu);
+    Vector3d calc_net_torque(Vector3d vel_enu, Vector3d pos_enu);
     RungeKuttaState calc_state(double tStamp, double tStep, RungeKuttaState k);
-    Vector3d i2ecef(Vector3d pos_if);
+    Vector3d i2ecef(Vector3d pos_enu);
     Vector3d ecef2geod(Vector3d ecef);
 };
 

--- a/includes/PhysicsEngine.h
+++ b/includes/PhysicsEngine.h
@@ -14,7 +14,6 @@
 
 #ifndef _PHYSICS_ENGINE_H_
 #define _PHYSICS_ENGINE_H_
-#define _USE_MATH_DEFINES
 
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
@@ -68,8 +67,6 @@ class RungeKutta : public PhysicsEngine {
     Vector3d calc_net_force(double tStamp, Vector3d pos_enu, Vector3d vel_enu);
     Vector3d calc_net_torque(Vector3d vel_enu, Vector3d pos_enu);
     RungeKuttaState calc_state(double tStamp, double tStep, RungeKuttaState k);
-    Vector3d i2ecef(Vector3d pos_enu);
-    Vector3d ecef2geod(Vector3d ecef);
 };
 
 #endif

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -150,12 +150,12 @@ class Rocket {
 
     std::array<double, 9> I_{};  // Rocket moment of inertia tensor
 
-    //The following are in Geocentric frame  
+    // The following are in Geocentric frame
     Vector3d launch_ecef_{150992.99, -4882549.85, 4087626.55};
     Vector3d launch_geod_{40.111801, -88.228691, 216};
-    Vector3d r_geod_{40.111801, -88.228691, 216};     // (40.111801, -88.228691, 216) - Talbot Laboratory
+    Vector3d r_geod_{40.111801, -88.228691,
+                     216};  // (40.111801, -88.228691, 216) - Talbot Laboratory
     Vector3d r_ecef_{150992.99, -4882549.85, 4087626.55};
-
 
     // Default scalar parameters from OpenRocket
     double mass_ = 41.034;      // in Kg

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -65,6 +65,7 @@ class Rocket {
     void get_r_geod(Vector3d& vector) const { vector = r_geod_; };
     void get_r_ecef(Vector3d& vector) const { vector = r_ecef_; };
     void get_launch_ecef(Vector3d& vector) const { vector = launch_ecef_; };
+    void get_launch_geod(Vector3d& vector) const { vector = launch_geod_; };
 
     /************ Get parameters by value (return by value) ***************/
     Vector3d get_r_vect() const { return r_vect_; };
@@ -92,6 +93,7 @@ class Rocket {
     Vector3d get_r_geod() const { return r_geod_; };
     Vector3d get_r_ecef() const { return r_ecef_; };
     Vector3d get_launch_ecef() const { return launch_ecef_; };
+    Vector3d get_launch_geod() const { return launch_geod_; };
 
     /************* Set parameters (all passed by reference) ***************/
     void set_r_vect(Vector3d& vector) { r_vect_ = vector; };
@@ -150,6 +152,7 @@ class Rocket {
 
     //The following are in Geocentric frame  
     Vector3d launch_ecef_{150992.99, -4882549.85, 4087626.55};
+    Vector3d launch_geod_{40.111801, -88.228691, 216};
     Vector3d r_geod_{40.111801, -88.228691, 216};     // (40.111801, -88.228691, 216) - Talbot Laboratory
     Vector3d r_ecef_{150992.99, -4882549.85, 4087626.55};
 

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -62,11 +62,6 @@ class Rocket {
 
     void get_Cp_vect(Vector3d& vector) const;
 
-    void get_r_geod(Vector3d& vector) const { vector = r_geod_; };
-    void get_r_ecef(Vector3d& vector) const { vector = r_ecef_; };
-    void get_launch_ecef(Vector3d& vector) const { vector = launch_ecef_; };
-    void get_launch_geod(Vector3d& vector) const { vector = launch_geod_; };
-
     /************ Get parameters by value (return by value) ***************/
     Vector3d get_r_vect() const { return r_vect_; };
     Vector3d get_r_dot() const { return r_dot_; };
@@ -125,25 +120,25 @@ class Rocket {
     void set_r_geod(Vector3d& vector) { r_geod_ = vector; };
     void set_r_ecef(Vector3d& vector) { r_ecef_ = vector; };
 
-    // Converts vector from inertial frame to rocket reference frame
-    Vector3d i2r(Vector3d vector);
+    // Converts vector from ENU frame to rocket reference frame
+    Vector3d enu2r(Vector3d vector);
 
-    // Converts vector from rocket frame to inertial reference frame
-    Vector3d r2i(Vector3d vector);
+    // Converts vector from rocket frame to ENU reference frame
+    Vector3d r2enu(Vector3d vector);
 
    private:
-    // The following are in inertial frame
+    // The following are in ENU frame
     Vector3d r_vect_{0, 0, 0};  // r vector
     Vector3d r_dot_{0, 0, 0};   // r-dot (velocity)
     Vector3d r_ddot_{0, 0, 0};  // r-double-dot (acceleration)
     Vector3d w_vect_{0, 0, 0};  // angular velocity (omega) vector
     Vector3d w_dot_{0, 0, 0};   // angular acceleration vector
 
-    // The following are in inertial frame
+    // The following are in ENU frame
     Vector3d f_net_{0, 0, 0};  // net force in Netwons
     Vector3d t_net_{0, 0, 0};  // net torque in Newton*meters
 
-    Quaterniond q_ornt_{};  // inertial -> rocket frame quaternion
+    Quaterniond q_ornt_{};  // ENU -> rocket frame quaternion
 
     // The following are in rocket frame
     Vector3d Cp_vect_{};  // CG to Cp vector

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -64,6 +64,7 @@ class Rocket {
 
     void get_r_geod(Vector3d& vector) const { vector = r_geod_; };
     void get_r_ecef(Vector3d& vector) const { vector = r_ecef_; };
+    void get_launch_ecef(Vector3d& vector) const { vector = launch_ecef_; };
 
     /************ Get parameters by value (return by value) ***************/
     Vector3d get_r_vect() const { return r_vect_; };
@@ -90,6 +91,7 @@ class Rocket {
 
     Vector3d get_r_geod() const { return r_geod_; };
     Vector3d get_r_ecef() const { return r_ecef_; };
+    Vector3d get_launch_ecef() const { return launch_ecef_; };
 
     /************* Set parameters (all passed by reference) ***************/
     void set_r_vect(Vector3d& vector) { r_vect_ = vector; };
@@ -147,6 +149,7 @@ class Rocket {
     std::array<double, 9> I_{};  // Rocket moment of inertia tensor
 
     //The following are in Geocentric frame  
+    Vector3d launch_ecef_{150992.99, -4882549.85, 4087626.55};
     Vector3d r_geod_{40.111801, -88.228691, 216};     // (40.111801, -88.228691, 216) - Talbot Laboratory
     Vector3d r_ecef_{150992.99, -4882549.85, 4087626.55};
 

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -62,6 +62,9 @@ class Rocket {
 
     void get_Cp_vect(Vector3d& vector) const;
 
+    void get_r_geod(Vector3d& vector) const { vector = r_geod_; };
+    void get_r_ecef(Vector3d& vector) const { vector = r_ecef_; };
+
     /************ Get parameters by value (return by value) ***************/
     Vector3d get_r_vect() const { return r_vect_; };
     Vector3d get_r_dot() const { return r_dot_; };
@@ -85,7 +88,6 @@ class Rocket {
 
     Vector3d get_Cp_vect() const { return Cp_vect_; };
 
-    Vector3d get_launch_ecef_coords() const { return launch_ecef_coords_; };
     Vector3d get_r_geod() const { return r_geod_; };
     Vector3d get_r_ecef() const { return r_ecef_; };
 
@@ -144,10 +146,9 @@ class Rocket {
 
     std::array<double, 9> I_{};  // Rocket moment of inertia tensor
 
-    //The following are in Geocentric frame
-    Vector3d launch_ecef_coords_{0, 0, 0};  // (40.111801, -88.228691, 216) - Talbot Laboratory
-    Vector3d r_geod_{0, 0, 0};
-    Vector3d r_ecef_{0, 0, 0};
+    //The following are in Geocentric frame  
+    Vector3d r_geod_{40.111801, -88.228691, 216};     // (40.111801, -88.228691, 216) - Talbot Laboratory
+    Vector3d r_ecef_{150992.99, -4882549.85, 4087626.55};
 
 
     // Default scalar parameters from OpenRocket

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -15,6 +15,7 @@
 
 #ifndef _ROCKET_H_
 #define _ROCKET_H_
+#define _USE_MATH_DEFINES
 
 #include <Eigen/Dense>
 #include <array>
@@ -86,7 +87,6 @@ class Rocket {
     Vector3d get_Cp_vect() const { return Cp_vect_; };
 
     Vector3d get_r_geod() const { return r_geod_; };
-    Vector3d get_r_ecef() const { return r_ecef_; };
     Vector3d get_launch_ecef() const { return launch_ecef_; };
     Vector3d get_launch_geod() const { return launch_geod_; };
 
@@ -117,14 +117,19 @@ class Rocket {
     void set_nose_to_cg(double& nose_to_cg);
     void set_nose_to_cp(double& nose_to_cp);
 
-    void set_r_geod(Vector3d& vector) { r_geod_ = vector; };
-    void set_r_ecef(Vector3d& vector) { r_ecef_ = vector; };
+    void set_r_geod(Vector3d vector) { r_geod_ = vector; };
 
     // Converts vector from ENU frame to rocket reference frame
     Vector3d enu2r(Vector3d vector);
 
     // Converts vector from rocket frame to ENU reference frame
     Vector3d r2enu(Vector3d vector);
+
+    // Converts vector from ENU frame to ECEF reference frame
+    Vector3d enu2ecef(Vector3d pos_enu);
+
+    // Converts vector from ECEF frame to Geodetic reference frame
+    Vector3d ecef2geod(Vector3d ecef);
 
    private:
     // The following are in ENU frame
@@ -150,7 +155,6 @@ class Rocket {
     Vector3d launch_geod_{40.111801, -88.228691, 216};
     Vector3d r_geod_{40.111801, -88.228691,
                      216};  // (40.111801, -88.228691, 216) - Talbot Laboratory
-    Vector3d r_ecef_{150992.99, -4882549.85, 4087626.55};
 
     // Default scalar parameters from OpenRocket
     double mass_ = 41.034;      // in Kg

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -85,6 +85,10 @@ class Rocket {
 
     Vector3d get_Cp_vect() const { return Cp_vect_; };
 
+    Vector3d get_launch_ecef_coords() const { return launch_ecef_coords_; };
+    Vector3d get_r_geod() const { return r_geod_; };
+    Vector3d get_r_ecef() const { return r_ecef_; };
+
     /************* Set parameters (all passed by reference) ***************/
     void set_r_vect(Vector3d& vector) { r_vect_ = vector; };
     void set_r_dot(Vector3d& vector) { r_dot_ = vector; };
@@ -112,6 +116,9 @@ class Rocket {
     void set_nose_to_cg(double& nose_to_cg);
     void set_nose_to_cp(double& nose_to_cp);
 
+    void set_r_geod(Vector3d& vector) { r_geod_ = vector; };
+    void set_r_ecef(Vector3d& vector) { r_ecef_ = vector; };
+
     // Converts vector from inertial frame to rocket reference frame
     Vector3d i2r(Vector3d vector);
 
@@ -138,6 +145,7 @@ class Rocket {
     std::array<double, 9> I_{};  // Rocket moment of inertia tensor
 
     //The following are in Geocentric frame
+    Vector3d launch_ecef_coords_{0, 0, 0};
     Vector3d r_geod_{0, 0, 0};
     Vector3d r_ecef_{0, 0, 0};
 

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -137,6 +137,11 @@ class Rocket {
 
     std::array<double, 9> I_{};  // Rocket moment of inertia tensor
 
+    //The following are in Geocentric frame
+    Vector3d r_geod_{0, 0, 0};
+    Vector3d r_ecef_{0, 0, 0};
+
+
     // Default scalar parameters from OpenRocket
     double mass_ = 41.034;      // in Kg
     double d_ref_ = 0.0157;     // ref length in m

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -57,7 +57,6 @@ class Rocket {
 
     Vector3d get_Cp_vect() const { return Cp_vect_; };
 
-    Vector3d get_r_geod() const { return r_geod_; };
     Vector3d get_launch_ecef() const { return launch_ecef_; };
     Vector3d get_launch_geod() const { return launch_geod_; };
 
@@ -92,8 +91,6 @@ class Rocket {
         Cp_vect_ = {0, 0, -(nose_to_cp_ - nose_to_cg_)};
     };
 
-    void set_r_geod(Vector3d vector) { r_geod_ = vector; };
-
     // Converts vector from ENU frame to rocket reference frame
     Vector3d enu2r(Vector3d vector);
 
@@ -127,9 +124,9 @@ class Rocket {
 
     // The following are in Geocentric frame
     Vector3d launch_ecef_{150992.99, -4882549.85, 4087626.55};
-    Vector3d launch_geod_{40.111801, -88.228691, 216};
-    Vector3d r_geod_{40.111801, -88.228691,
-                     216};  // (40.111801, -88.228691, 216) - Talbot Laboratory
+    Vector3d launch_geod_{
+        40.111801, -88.228691,
+        216};  // (40.111801, -88.228691, 216) - Talbot Laboratory
 
     // Default scalar parameters from OpenRocket
     double mass_ = 41.034;      // in Kg

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -145,7 +145,7 @@ class Rocket {
     std::array<double, 9> I_{};  // Rocket moment of inertia tensor
 
     //The following are in Geocentric frame
-    Vector3d launch_ecef_coords_{0, 0, 0};
+    Vector3d launch_ecef_coords_{0, 0, 0};  // (40.111801, -88.228691, 216) - Talbot Laboratory
     Vector3d r_geod_{0, 0, 0};
     Vector3d r_ecef_{0, 0, 0};
 

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -507,17 +507,17 @@ Vector3d RungeKutta::i2ecef(Vector3d pos_if) {
 }
 
 Vector3d RungeKutta::ecef2geod(Vector3d ecef) {
-    Vector3d geod;
+    Vector3d geod = rocket_.get_r_geod();
     
     const double a = 6378137.0;
     const double b = 6356752.3142;
     const double e = (std::pow(a, 2) - std::pow(b, 2)) / std::pow(a, 2);
     double p = std::sqrt(std::pow(ecef.x(), 2) + std::pow(ecef.y(), 2));
-    double n = a / (std::sqrt(1 - (std::pow(e, 2) * std::pow(std::sin(ecef.x()), 2))));
+    double n = a / (std::sqrt(1 - (e * std::pow(std::sin(geod.x()), 2))));
 
     geod.y() = std::atan2(ecef.y(), ecef.x());
-    geod.z() = (p / std::cos(ecef.x())) - n;
-    geod.x() = std::atan((ecef.z() / p) / (1 - (std::pow(e, 2) * n / (n - geod.z()))));
+    geod.z() = (p / std::cos(geod.x())) - n;
+    geod.x() = std::atan((ecef.z() / p) / (1 - (e * n / (n - geod.z()))));
 
     return geod;
 }

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -495,6 +495,12 @@ Quaterniond PhysicsEngine::update_quaternion(Quaterniond q_ornt,
     return q_ornt;
 }
 
+/**
+ * @brief 
+ * 
+ * @param pos_if 
+ * @return Vector3d 
+ */
 Vector3d RungeKutta::i2ecef(Vector3d pos_if) {
     double lambda = rocket_.get_launch_geod().y() * M_PI / 180;
     double lat = rocket_.get_launch_geod().x() * M_PI / 180;
@@ -512,6 +518,12 @@ Vector3d RungeKutta::i2ecef(Vector3d pos_if) {
     return ecef;
 }
 
+/**
+ * @brief 
+ * 
+ * @param ecef 
+ * @return Vector3d 
+ */
 Vector3d RungeKutta::ecef2geod(Vector3d ecef) {
     Vector3d geod = rocket_.get_r_geod();
 

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -123,7 +123,7 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
     }
 
     f_net_enu = rocket_.r2enu(f_aero_rf + thrust_rf);
-    f_net_enu.z() -= (9.81 * mass);
+    f_net_enu -= rocket_.ecef2geod(rocket_.enu2ecef({0, 0, (9.81 * mass)}));
 
     t_net_rf = t_aero_rf;
     t_net_enu = rocket_.r2enu(t_aero_rf);
@@ -334,7 +334,7 @@ Vector3d RungeKutta::calc_net_force(double tStamp, Vector3d pos_enu,
     }
 
     Vector3d net_force_enu = rocket_.r2enu(aero_force_rf + thrust_rf);
-    net_force_enu.z() -= (9.81 * mass);
+    net_force_enu -= rocket_.ecef2geod(rocket_.enu2ecef({0, 0, (9.81 * mass)}));
 
     return net_force_enu;
 }

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -498,36 +498,44 @@ Quaterniond PhysicsEngine::update_quaternion(Quaterniond q_ornt,
 
 Vector3d RungeKutta::i2ecef(Vector3d pos_if) {
     
-    double lambda = rocket_.get_r_geod().x();
-    double lat = rocket_.get_r_geod().y();
+    double lambda = rocket_.get_launch_geod().y() * M_PI / 180;
+    double lat = rocket_.get_launch_geod().x() * M_PI / 180;
     Vector3d ecef = rocket_.get_r_ecef();
-    std::cout << ecef.x() << " " << ecef.y() << " " << ecef.z() << std::endl;
 
     Eigen::Matrix<double, 3, 3> transform {
         {-std::sin(lambda), -std::sin(lat) * std::cos(lambda), std::cos(lat) * std::cos(lambda)},
         {std::cos(lambda), -std::sin(lat) * std::sin(lambda), std::cos(lat) * std::sin(lambda)},
         {0, std::cos(lat), std::sin(lat)}
     };
-
+    
     ecef = (transform * pos_if) + rocket_.get_launch_ecef();
+    
     return ecef;
 }
 
 Vector3d RungeKutta::ecef2geod(Vector3d ecef) {
     Vector3d geod = rocket_.get_r_geod();
-    std::cout << geod.x() << " " << geod.y() << " " << geod.z() << std::endl;
-    double h = geod.z();
-
     
     const double a = 6378137.0;
     const double b = 6356752.3142;
-    const double e = (std::pow(a, 2) - std::pow(b, 2)) / std::pow(a, 2);
+    const double e2 = (std::pow(a, 2) - std::pow(b, 2)) / std::pow(a, 2);
+    const double er2 = (std::pow(a, 2) - std::pow(b, 2)) / std::pow(b, 2);
     double p = std::sqrt(std::pow(ecef.x(), 2) + std::pow(ecef.y(), 2));
-    double n = a / (std::sqrt(1 - (e * std::pow(std::sin(geod.x()), 2)))) * 180 / M_PI;
+    double F = 54 * std::pow(b, 2) * std::pow(ecef.z(), 2);
+    double G = std::pow(p, 2) + ((1 - e2) * std::pow(ecef.z(), 2)) - (e2 * (std::pow(a, 2) - std::pow(b, 2)));
+    double c = (std::pow(e2, 2) * F * std::pow(p, 2)) / std::pow(G, 3);
+    double s = std::cbrt(1 + c + std::sqrt(std::pow(c, 2) + (2 * c)));
+    double k = s + 1 + (1/s);
+    double P = F / (3 * std::pow(k, 2) * std::pow(G, 2));
+    double Q = std::sqrt(1 + (2 * std::pow(e2, 2) * P));
+    double r0 = ((-P * e2 * p) / (1 + Q)) + std::sqrt(((0.5 * std::pow(a, 2)) * (1 + (1 / Q))) - ((P * (1 - e2) * std::pow(ecef.z(), 2)) / (Q * (1 + Q))) - (0.5 * P * std::pow(p, 2)));
+    double U = std::sqrt(std::pow((p - (e2 * r0)), 2) + std::pow(ecef.z(), 2));
+    double V = std::sqrt(std::pow(p - (e2 * r0), 2) + ((1 - e2) * std::pow(ecef.z(), 2)));
+    double z0 = (std::pow(b, 2) * ecef.z()) / (a * V);
 
+    geod.z() = U * (1 - (std::pow(b, 2) / (a * V)));
+    geod.x() = std::atan((ecef.z() + (er2 * z0)) / p) * 180 / M_PI;
     geod.y() = std::atan2(ecef.y(), ecef.x()) * 180 / M_PI;
-    geod.z() = (p / std::cos(geod.x()) - n);
-    geod.x() = std::atan((ecef.z() / p) / (1 - (e * n / (n + h)))) * 180 / M_PI;
 
     return geod;
 }

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -15,7 +15,6 @@
 #include "PhysicsEngine.h"
 
 #include <Eigen/Dense>
-#include <cmath>
 
 #include "Atmosphere.h"
 
@@ -217,9 +216,6 @@ void RungeKutta::march_step(double tStamp, double tStep) {
 
     double mass = rocket_.get_mass();
 
-    Vector3d geod = rocket_.get_r_geod();
-    Vector3d ecef = rocket_.get_r_ecef();
-
     /******************** Calculate Intermediate States **********************/
     // Each state is used to calculate the next state
 
@@ -281,8 +277,7 @@ void RungeKutta::march_step(double tStamp, double tStep) {
     rocket_.set_t_net(net_torque_enu);
     rocket_.set_q_ornt(orient);
 
-    rocket_.set_r_ecef(i2ecef(pos_enu));
-    rocket_.set_r_geod(ecef2geod(ecef));
+    rocket_.set_r_geod(rocket_.ecef2geod(rocket_.enu2ecef(pos_enu)));
 }
 
 /**
@@ -307,7 +302,7 @@ Vector3d RungeKutta::calc_net_force(double tStamp, Vector3d pos_enu,
     double c_Na = rocket_.get_Cna();  // normal force coefficient derivative
     double drag_coef = rocket_.get_Cd();
 
-    Vector3d geod = ecef2geod(i2ecef(pos_enu));
+    Vector3d geod = rocket_.ecef2geod(rocket_.enu2ecef(pos_enu));
 
     /************************* Calculate Net Force ****************************/
 
@@ -367,7 +362,7 @@ Vector3d RungeKutta::calc_net_torque(Vector3d vel_enu, Vector3d pos_enu) {
     double c_Na = rocket_.get_Cna();  // normal force coefficient derivative
     double drag_coef = rocket_.get_Cd();
 
-    Vector3d geod = ecef2geod(i2ecef(pos_enu));
+    Vector3d geod = rocket_.ecef2geod(rocket_.enu2ecef(pos_enu));
 
     /************************ Calculate Net Torque ***************************/
 
@@ -493,105 +488,4 @@ Quaterniond PhysicsEngine::update_quaternion(Quaterniond q_ornt,
     q_ornt.normalize();
 
     return q_ornt;
-}
-
-/**
- * @brief Converts the rocket's ENU coordinates to ECEF
- *
- * Method takes in the position of the rocket in the East-North-Up reference
- * frame and pulls the latitude and longitude of the launchpad from the rocket
- * class.  The launchpad coordinates are converted into radians and used in the
- * transformation matrix.  The transformation matrix and the
- * Earth-Centered-Earth-Fixed (ecef) coordinates of the launchpad are used to
- * calculate the ecef position of the rocket.
- *
- * ENU is the distance East, North, and Up the rocket is from the origin in
- * meters ENU is a flat plane tangent to the earth, with an arbitrary but fixed
- * origin
- *
- * ECEF is the distance the rocket is from the center of mass of the earth
- * The X axis is the prime meridian and 180 degrees longitude, on the equator
- * The Y axis is 90 degrees east and 90 degrees west, on the equator
- * The Z axis is north and south
- *
- * https://en.wikipedia.org/wiki/Geographic_coordinate_conversion
- * "From ENU to ECEF"
- *
- * @param pos_enu Position of the rocket in the East-North-Up reference frame
- * @return Vector3d Position of the rocket in the Earth-Centered-Earth-Fixed
- * reference frame
- */
-Vector3d RungeKutta::i2ecef(Vector3d pos_enu) {
-    double lambda =
-        rocket_.get_launch_geod().y() * M_PI / 180;  // longitude of launchpad
-    double lat =
-        rocket_.get_launch_geod().x() * M_PI / 180;  // latitude of launchpad
-    Vector3d ecef = rocket_.get_r_ecef();
-
-    Eigen::Matrix<double, 3, 3> transform{
-        {-std::sin(lambda), -std::sin(lat) * std::cos(lambda),
-         std::cos(lat) * std::cos(lambda)},
-        {std::cos(lambda), -std::sin(lat) * std::sin(lambda),
-         std::cos(lat) * std::sin(lambda)},
-        {0, std::cos(lat), std::sin(lat)}};
-
-    ecef = (transform * pos_enu) + rocket_.get_launch_ecef();
-
-    return ecef;
-}
-
-/**
- * @brief Converts the rocket's Earth-Centered-Earth-Fixed coordinates into
- * Geodetic latitude, longitude, and altitude
- *
- * Method takes in the Earth-Centered-Earth-Fixed coordinates of the rocket.  It
- * then performs a series of calculations to determine the Geodetic latitude,
- * longitude, and altitude of the rocket.  Variable names other than "geod" are
- * not significant and only come from the reference math.
- *
- * ECEF is the distance the rocket is from the center of mass of the earth
- * The X axis is the prime meridian and 180 degrees longitude, on the equator
- * The Y axis is 90 degrees east and 90 degrees west, on the equator
- * The Z axis is north and south
- *
- * Geodetic is the latitude, longitude, and altitude of the rocket based on a
- * spheroid (squished) earth
- *
- * https://en.wikipedia.org/wiki/Geographic_coordinate_conversion
- * "The application of Ferrari's solution"
- *
- * @param ecef Earth-Centered-Earth-Fixed position of the rocket
- * @return Vector3d Geodetic latitude, longitude, and altitude of the rocket
- */
-Vector3d RungeKutta::ecef2geod(Vector3d ecef) {
-    Vector3d geod = rocket_.get_r_geod();
-
-    const double a = 6378137.0;
-    const double b = 6356752.3142;
-    const double e2 = (std::pow(a, 2) - std::pow(b, 2)) / std::pow(a, 2);
-    const double er2 = (std::pow(a, 2) - std::pow(b, 2)) / std::pow(b, 2);
-    double p = std::sqrt(std::pow(ecef.x(), 2) + std::pow(ecef.y(), 2));
-    double F = 54 * std::pow(b, 2) * std::pow(ecef.z(), 2);
-    double G = std::pow(p, 2) + ((1 - e2) * std::pow(ecef.z(), 2)) -
-               (e2 * (std::pow(a, 2) - std::pow(b, 2)));
-    double c = (std::pow(e2, 2) * F * std::pow(p, 2)) / std::pow(G, 3);
-    double s = std::cbrt(1 + c + std::sqrt(std::pow(c, 2) + (2 * c)));
-    double k = s + 1 + (1 / s);
-    double P = F / (3 * std::pow(k, 2) * std::pow(G, 2));
-    double Q = std::sqrt(1 + (2 * std::pow(e2, 2) * P));
-    double r0 =
-        ((-P * e2 * p) / (1 + Q)) +
-        std::sqrt(((0.5 * std::pow(a, 2)) * (1 + (1 / Q))) -
-                  ((P * (1 - e2) * std::pow(ecef.z(), 2)) / (Q * (1 + Q))) -
-                  (0.5 * P * std::pow(p, 2)));
-    double U = std::sqrt(std::pow((p - (e2 * r0)), 2) + std::pow(ecef.z(), 2));
-    double V = std::sqrt(std::pow(p - (e2 * r0), 2) +
-                         ((1 - e2) * std::pow(ecef.z(), 2)));
-    double z0 = (std::pow(b, 2) * ecef.z()) / (a * V);
-
-    geod.z() = U * (1 - (std::pow(b, 2) / (a * V)));
-    geod.x() = std::atan((ecef.z() + (er2 * z0)) / p) * 180 / M_PI;
-    geod.y() = std::atan2(ecef.y(), ecef.x()) * 180 / M_PI;
-
-    return geod;
 }

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -16,6 +16,7 @@
 
 #include <Eigen/Dense>
 #include <cmath>
+#include <iostream>
 
 #include "Atmosphere.h"
 
@@ -496,17 +497,25 @@ Quaterniond PhysicsEngine::update_quaternion(Quaterniond q_ornt,
 }
 
 Vector3d RungeKutta::i2ecef(Vector3d pos_if) {
-    double lambda = 0.0;
-    double lat = 0.0;
+    double lambda = rocket_.get_r_geod().x();
+    double lat = rocket_.get_r_geod().y();
     Vector3d ecef = rocket_.get_r_ecef();
+    
+    Eigen::Matrix<double, 1, 3> enu {
+        {pos_if.x()},
+        {pos_if.y()},
+        {pos_if.z()}
+    };
 
     Eigen::Matrix<double, 3, 3> transform {
         {-std::sin(lambda), -std::sin(lat) * std::cos(lambda), std::cos(lat) * std::cos(lambda)},
         {std::cos(lambda), -std::sin(lat) * std::sin(lambda), std::cos(lat) * std::sin(lambda)},
         {0, std::cos(lat), std::sin(lat)}
     };
+    Eigen::Matrix<double, 3, 1> mult = transform * enu;
 
-    ecef += (transform * pos_if);
+    Vector3d new_ecef = {mult(0, 0), mult(0, 1), mult(0, 2)};
+    ecef += new_ecef;
     return ecef;
 }
 

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -16,7 +16,6 @@
 
 #include <Eigen/Dense>
 #include <cmath>
-#include <iostream>
 
 #include "Atmosphere.h"
 
@@ -308,7 +307,7 @@ Vector3d RungeKutta::calc_net_force(double tStamp, Vector3d pos_if,
     double c_Na = rocket_.get_Cna();  // normal force coefficient derivative
     double drag_coef = rocket_.get_Cd();
 
-    Vector3d geod = rocket_.get_r_geod();
+    Vector3d geod = ecef2geod(i2ecef(pos_if));
 
     /************************* Calculate Net Force ****************************/
 
@@ -326,14 +325,14 @@ Vector3d RungeKutta::calc_net_force(double tStamp, Vector3d pos_if,
         double normal_coef = c_Na * alpha;
 
         double normal_force_mag = 0.5 * normal_coef * vel_rf.squaredNorm() *
-                                  area * Atmosphere::get_density(pos_if.z());
+                                  area * Atmosphere::get_density(geod.z());
         normal_force_rf = {(-vel_rf.x()), (-vel_rf.y()), 0};
 
         normal_force_rf.normalize();
         normal_force_rf = normal_force_rf * normal_force_mag;
 
         double drag_mag = 0.5 * drag_coef * vel_rf.squaredNorm() * area *
-                          Atmosphere::get_density(pos_if.z());
+                          Atmosphere::get_density(geod.z());
         Vector3d drag_rf{0, 0, std::copysign(drag_mag, -vel_rf.z())};
 
         aero_force_rf = normal_force_rf + drag_rf;
@@ -368,7 +367,7 @@ Vector3d RungeKutta::calc_net_torque(Vector3d vel_if, Vector3d pos_if) {
     double c_Na = rocket_.get_Cna();  // normal force coefficient derivative
     double drag_coef = rocket_.get_Cd();
 
-    Vector3d geod = rocket_.get_r_geod();
+    Vector3d geod = ecef2geod(i2ecef(pos_if));
 
     /************************ Calculate Net Torque ***************************/
 
@@ -389,14 +388,14 @@ Vector3d RungeKutta::calc_net_torque(Vector3d vel_if, Vector3d pos_if) {
         double normal_coef = c_Na * alpha;
 
         double normal_force_mag = 0.5 * normal_coef * vel_rf.squaredNorm() *
-                                  area * Atmosphere::get_density(pos_if.z());
+                                  area * Atmosphere::get_density(geod.z());
         normal_force_rf = {(-vel_rf.x()), (-vel_rf.y()), 0};
 
         normal_force_rf.normalize();
         normal_force_rf = normal_force_rf * normal_force_mag;
 
         double drag_mag = 0.5 * drag_coef * vel_rf.squaredNorm() * area *
-                          Atmosphere::get_density(pos_if.z());
+                          Atmosphere::get_density(geod.z());
         Vector3d drag_rf{0, 0, std::copysign(drag_mag, -vel_rf.z())};
 
         aero_force_rf = normal_force_rf + drag_rf;

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -125,10 +125,13 @@ void ForwardEuler::march_step(double tStamp, double tStep) {
         t_aero_rf.z() = 0;
     }
 
-    Vector3d deg_dif = (geod - rocket_.get_launch_geod()) * M_PI / 180;
-    Vector3d gravity_geod = {std::sin(deg_dif.x()) * std::cos(deg_dif.y()),
-                             std::sin(deg_dif.x()) * std::sin(deg_dif.y()),
-                             std::cos(deg_dif.x())};
+    // difference in geoditic radians between rocket position and launchpad
+    Vector3d rad_dif = (geod - rocket_.get_launch_geod()) * M_PI / 180;
+
+    // converts gravity from enu to geod
+    Vector3d gravity_geod = {std::sin(rad_dif.x()) * std::cos(rad_dif.y()),
+                             std::sin(rad_dif.x()) * std::sin(rad_dif.y()),
+                             std::cos(rad_dif.x())};
 
     f_net_enu = rocket_.r2enu(f_aero_rf + thrust_rf);
     f_net_enu -= (gravity_geod * 9.81 * mass);
@@ -339,10 +342,14 @@ Vector3d RungeKutta::calc_net_force(double tStamp, Vector3d pos_enu,
         aero_force_rf = {0, 0, 0};
     }
 
-    Vector3d deg_dif = (geod - rocket_.get_launch_geod()) * M_PI / 180;
-    Vector3d gravity_geod = {std::sin(deg_dif.x()) * std::cos(deg_dif.y()),
-                             std::sin(deg_dif.x()) * std::sin(deg_dif.y()),
-                             std::cos(deg_dif.x())};
+    // difference in geoditic radians between rocket position and launchpad
+    Vector3d rad_dif = (geod - rocket_.get_launch_geod()) * M_PI / 180;
+
+    // converts gravity from enu to geod
+    Vector3d gravity_geod = {std::sin(rad_dif.x()) * std::cos(rad_dif.y()),
+                             std::sin(rad_dif.x()) * std::sin(rad_dif.y()),
+                             std::cos(rad_dif.x())};
+
     Vector3d net_force_enu = rocket_.r2enu(aero_force_rf + thrust_rf);
     net_force_enu -= (gravity_geod * 9.81 * mass);
 

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -307,6 +307,8 @@ Vector3d RungeKutta::calc_net_force(double tStamp, Vector3d pos_if,
     double c_Na = rocket_.get_Cna();  // normal force coefficient derivative
     double drag_coef = rocket_.get_Cd();
 
+    Vector3d geod = rocket_.get_r_geod();
+
     /************************* Calculate Net Force ****************************/
 
     Vector3d aero_force_rf;
@@ -364,6 +366,8 @@ Vector3d RungeKutta::calc_net_torque(Vector3d vel_if, Vector3d pos_if) {
     double area = rocket_.get_A_ref();
     double c_Na = rocket_.get_Cna();  // normal force coefficient derivative
     double drag_coef = rocket_.get_Cd();
+
+    Vector3d geod = rocket_.get_r_geod();
 
     /************************ Calculate Net Torque ***************************/
 
@@ -494,7 +498,7 @@ Quaterniond PhysicsEngine::update_quaternion(Quaterniond q_ornt,
 Vector3d RungeKutta::i2ecef(Vector3d pos_if) {
     double lambda = 0.0;
     double lat = 0.0;
-    Vector3d ecef = rocket_.get_launch_ecef_coords();
+    Vector3d ecef = rocket_.get_r_ecef();
 
     Eigen::Matrix<double, 3, 3> transform {
         {-std::sin(lambda), -std::sin(lat) * std::cos(lambda), std::cos(lat) * std::cos(lambda)},

--- a/src/Rocket.cpp
+++ b/src/Rocket.cpp
@@ -14,6 +14,7 @@
 #include "Rocket.h"
 
 #include <Eigen/Dense>
+#include <cmath>
 
 using Eigen::Quaterniond;
 using Eigen::Vector3d;
@@ -94,4 +95,104 @@ Vector3d Rocket::r2enu(Vector3d vector) {
     p = (q_ornt_ * p) * q_ornt_.conjugate();
 
     return p.vec();
+}
+
+/**
+ * @brief Converts the rocket's ENU coordinates to ECEF
+ *
+ * Method takes in the position of the rocket in the East-North-Up reference
+ * frame and pulls the latitude and longitude of the launchpad from the rocket
+ * class.  The launchpad coordinates are converted into radians and used in the
+ * transformation matrix.  The transformation matrix and the
+ * Earth-Centered-Earth-Fixed (ecef) coordinates of the launchpad are used to
+ * calculate the ecef position of the rocket.
+ *
+ * ENU is the distance East, North, and Up the rocket is from the origin in
+ * meters ENU is a flat plane tangent to the earth, with an arbitrary but fixed
+ * origin
+ *
+ * ECEF is the distance the rocket is from the center of mass of the earth
+ * The X axis is the prime meridian and 180 degrees longitude, on the equator
+ * The Y axis is 90 degrees east and 90 degrees west, on the equator
+ * The Z axis is north and south
+ *
+ * https://en.wikipedia.org/wiki/Geographic_coordinate_conversion
+ * "From ENU to ECEF"
+ *
+ * @param pos_enu Position of the rocket in the East-North-Up reference frame
+ * @return Vector3d Position of the rocket in the Earth-Centered-Earth-Fixed
+ * reference frame
+ */
+Vector3d Rocket::enu2ecef(Vector3d pos_enu) {
+    double lambda =
+        get_launch_geod().y() * M_PI / 180;           // longitude of launchpad
+    double lat = get_launch_geod().x() * M_PI / 180;  // latitude of launchpad
+    Vector3d ecef;
+
+    Eigen::Matrix<double, 3, 3> transform{
+        {-std::sin(lambda), -std::sin(lat) * std::cos(lambda),
+         std::cos(lat) * std::cos(lambda)},
+        {std::cos(lambda), -std::sin(lat) * std::sin(lambda),
+         std::cos(lat) * std::sin(lambda)},
+        {0, std::cos(lat), std::sin(lat)}};
+
+    ecef = (transform * pos_enu) + get_launch_ecef();
+
+    return ecef;
+}
+
+/**
+ * @brief Converts the rocket's Earth-Centered-Earth-Fixed coordinates into
+ * Geodetic latitude, longitude, and altitude
+ *
+ * Method takes in the Earth-Centered-Earth-Fixed coordinates of the rocket.  It
+ * then performs a series of calculations to determine the Geodetic latitude,
+ * longitude, and altitude of the rocket.  Variable names other than "geod" are
+ * not significant and only come from the reference math.
+ *
+ * ECEF is the distance the rocket is from the center of mass of the earth
+ * The X axis is the prime meridian and 180 degrees longitude, on the equator
+ * The Y axis is 90 degrees east and 90 degrees west, on the equator
+ * The Z axis is north and south
+ *
+ * Geodetic is the latitude, longitude, and altitude of the rocket based on a
+ * spheroid (squished) earth
+ *
+ * https://en.wikipedia.org/wiki/Geographic_coordinate_conversion
+ * "The application of Ferrari's solution"
+ *
+ * @param ecef Earth-Centered-Earth-Fixed position of the rocket
+ * @return Vector3d Geodetic latitude, longitude, and altitude of the rocket
+ */
+Vector3d Rocket::ecef2geod(Vector3d ecef) {
+    Vector3d geod = get_r_geod();
+
+    const double a = 6378137.0;
+    const double b = 6356752.3142;
+    const double e2 = (std::pow(a, 2) - std::pow(b, 2)) / std::pow(a, 2);
+    const double er2 = (std::pow(a, 2) - std::pow(b, 2)) / std::pow(b, 2);
+    double p = std::sqrt(std::pow(ecef.x(), 2) + std::pow(ecef.y(), 2));
+    double F = 54 * std::pow(b, 2) * std::pow(ecef.z(), 2);
+    double G = std::pow(p, 2) + ((1 - e2) * std::pow(ecef.z(), 2)) -
+               (e2 * (std::pow(a, 2) - std::pow(b, 2)));
+    double c = (std::pow(e2, 2) * F * std::pow(p, 2)) / std::pow(G, 3);
+    double s = std::cbrt(1 + c + std::sqrt(std::pow(c, 2) + (2 * c)));
+    double k = s + 1 + (1 / s);
+    double P = F / (3 * std::pow(k, 2) * std::pow(G, 2));
+    double Q = std::sqrt(1 + (2 * std::pow(e2, 2) * P));
+    double r0 =
+        ((-P * e2 * p) / (1 + Q)) +
+        std::sqrt(((0.5 * std::pow(a, 2)) * (1 + (1 / Q))) -
+                  ((P * (1 - e2) * std::pow(ecef.z(), 2)) / (Q * (1 + Q))) -
+                  (0.5 * P * std::pow(p, 2)));
+    double U = std::sqrt(std::pow((p - (e2 * r0)), 2) + std::pow(ecef.z(), 2));
+    double V = std::sqrt(std::pow(p - (e2 * r0), 2) +
+                         ((1 - e2) * std::pow(ecef.z(), 2)));
+    double z0 = (std::pow(b, 2) * ecef.z()) / (a * V);
+
+    geod.z() = U * (1 - (std::pow(b, 2) / (a * V)));
+    geod.x() = std::atan((ecef.z() + (er2 * z0)) / p) * 180 / M_PI;
+    geod.y() = std::atan2(ecef.y(), ecef.x()) * 180 / M_PI;
+
+    return geod;
 }

--- a/src/Rocket.cpp
+++ b/src/Rocket.cpp
@@ -70,13 +70,13 @@ void Rocket::set_nose_to_cp(double& nose_to_cp) {
 void Rocket::get_Cp_vect(Vector3d& vector) const { vector = Cp_vect_; }
 
 /**
- * @brief Performs a quaternion rotation to translate a vector from the inertial
+ * @brief Performs a quaternion rotation to translate a vector from the ENU
  * frame to the rocket body frame.
  *
  * @param vector Input vector in intertial frame to be rotated
  * @return Vector3d The rotated vector represented in the rocket body frame
  */
-Vector3d Rocket::i2r(Vector3d vector) {
+Vector3d Rocket::enu2r(Vector3d vector) {
     Quaterniond p{0, vector.x(), vector.y(), vector.z()};
     p = (q_ornt_.conjugate() * p) * q_ornt_;
     return p.vec();
@@ -84,12 +84,12 @@ Vector3d Rocket::i2r(Vector3d vector) {
 
 /**
  * @brief Performs a quaternion rotation to translate a vector from the rocket
- * frame to the inertial reference frame.
+ * frame to the ENU reference frame.
  *
  * @param vector Input vector in rocket frame to be rotated
- * @return Vector3d The rotated vector represented in the inertial frame
+ * @return Vector3d The rotated vector represented in the ENU frame
  */
-Vector3d Rocket::r2i(Vector3d vector) {
+Vector3d Rocket::r2enu(Vector3d vector) {
     Quaterniond p{0, vector.x(), vector.y(), vector.z()};
     p = (q_ornt_ * p) * q_ornt_.conjugate();
 

--- a/src/Rocket.cpp
+++ b/src/Rocket.cpp
@@ -114,7 +114,7 @@ Vector3d Rocket::enu2ecef(Vector3d pos_enu) {
  * @return Vector3d Geodetic latitude, longitude, and altitude of the rocket
  */
 Vector3d Rocket::ecef2geod(Vector3d ecef) {
-    Vector3d geod = get_r_geod();
+    Vector3d geod;
 
     const double a = 6378137.0;
     const double b = 6356752.3142;

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -56,7 +56,7 @@ Gyroscope::Gyroscope(std::string name, Rocket& rocket, double refresh_rate,
 void Gyroscope::update_data(double tStep) {
     if ((tStep - last_update_tStep_) >= (1 / refresh_rate_)) {
         rocket_.get_w_vect(data_);
-        rocket_.i2r(data_);
+        rocket_.enu2r(data_);
         new_data_ = true;
 
         if (inject_noise_) {
@@ -87,7 +87,7 @@ Accelerometer::Accelerometer(std::string name, Rocket& rocket,
 void Accelerometer::update_data(double tStep) {
     if ((tStep - last_update_tStep_) >= (1 / refresh_rate_)) {
         rocket_.get_r_ddot(data_);
-        rocket_.i2r(data_);
+        rocket_.enu2r(data_);
         new_data_ = true;
 
         if (inject_noise_) {

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -64,7 +64,7 @@ void Simulation::run(int steps) {
 
     motor_.ignite(tStamp_);
     for (int iter = 0; iter < steps; ++iter) {
-        rocket_.get_r_geod(r_vect);
+        r_vect = rocket_.get_r_geod();
         rocket_.get_r_dot(r_dot);
         rocket_.get_r_ddot(r_ddot);
         rocket_.get_f_net(f_net);
@@ -84,7 +84,7 @@ void Simulation::run(int steps) {
         roll = atan2(2.0 * (s * z + x * y), -1.0 + 2.0 * (s * s + x * x)) *
                RAD2DEG;
 
-        double alpha = acos(rocket_.i2r(r_dot).z() / (r_dot.norm()));
+        double alpha = acos(rocket_.enu2r(r_dot).z() / (r_dot.norm()));
         sim_log->debug("Timestamp: {}", tStamp_);
         sim_log->debug("R-Vector: <{}, {}, {}>", r_vect.x(), r_vect.y(),
                        r_vect.z());
@@ -97,7 +97,7 @@ void Simulation::run(int steps) {
         sim_log->debug("ROLL: {} PITCH: {} YAW: {}  [deg]", roll, pitch, yaw);
         sim_log->debug("alphaSIM: {}  [deg]", alpha * RAD2DEG);
         Vector3d rocket_axis(0, 0, 1);
-        rocket_axis = rocket_.r2i(rocket_axis);
+        rocket_axis = rocket_.r2enu(rocket_axis);
 
         engine_->march_step(tStamp_, tStep_);
 

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -64,7 +64,7 @@ void Simulation::run(int steps) {
 
     motor_.ignite(tStamp_);
     for (int iter = 0; iter < steps; ++iter) {
-        rocket_.get_r_vect(r_vect);
+        rocket_.get_r_geod(r_vect);
         rocket_.get_r_dot(r_dot);
         rocket_.get_r_ddot(r_ddot);
         rocket_.get_f_net(f_net);

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -54,7 +54,8 @@ void Simulation::run(int steps) {
 
     motor_.ignite(tStamp_);
     for (int iter = 0; iter < steps; ++iter) {
-        Vector3d r_vect = rocket_.get_r_geod();
+        Vector3d r_vect =
+            rocket_.ecef2geod(rocket_.enu2ecef(rocket_.get_r_vect()));
         Vector3d r_dot = rocket_.get_r_dot();
         Vector3d r_ddot = rocket_.get_r_ddot();
         Vector3d f_net = rocket_.get_f_net();


### PR DESCRIPTION
New functions that convert the existing inertial frame position to Earth-Centered-Earth-Fixed and Geodetic reference frames.
Physics engine now passes geodetic altitude to the atmosphere class.
 [Math](https://en.wikipedia.org/wiki/Geographic_coordinate_conversion)
[Trello](https://trello.com/c/TfpEDcMC/273-av-273-add-geodesic-earth-reference-frame-to-physics-engine)