### PR TITLE
[AV-545] move net force and moment calculation under rocket

### DIFF
--- a/includes/PhysicsEngine.h
+++ b/includes/PhysicsEngine.h
@@ -66,7 +66,7 @@ class RungeKutta : public PhysicsEngine {
     };
 
     Vector3d calc_net_force(double tStamp, Vector3d pos_enu, Vector3d vel_enu);
-    Vector3d calc_net_torque(Vector3d vel_enu, Vector3d pos_enu);
+    Vector3d calc_net_moment(Vector3d vel_enu, Vector3d pos_enu);
     RungeKuttaState calc_state(double tStamp, double tStep, RungeKuttaState k);
     Vector3d enu2ecef(Vector3d pos_enu);
     Vector3d ecef2geod(Vector3d ecef);

--- a/includes/PhysicsEngine.h
+++ b/includes/PhysicsEngine.h
@@ -8,7 +8,8 @@
  * The PhysicsEngine class encapsulates a particular algorithm that is used
  * to advance the state of the simulation in time. These algorithms are
  * commonly responsible for calculating time varying quantities that govern
- * the trajectory of the rocket, such as angular and axial acceleration.
+ * the trajectory of the rocket, such as angular and axial acceleration,
+ * velocity and position.
  *
  */
 
@@ -25,6 +26,22 @@
 #include "Propulsion.h"
 #include "Rocket.h"
 
+/*****************************************************************************/
+/* PhysicsEngine Base Class and Derivatives */
+/*****************************************************************************/
+
+/** PhysicsEngine Base Class
+ * This class is a pure virtual class that defines an interface that physics
+ * engine implementations need to abide by. i.e. all implementations that derive
+ * from this class will need to have a "march_step()" function that marches the
+ * simulation physics forward by one step. The algorithm used to do so depends
+ * on the particular implementation
+ *
+ * This class is also the home for some commonly used utility funcitons. These
+ * utility functions are in the protected segment of the class, which means
+ * their implementations are shared with child classes that inherit from this
+ * base class.
+ */
 class PhysicsEngine {
    public:
     PhysicsEngine(Rocket& rocket, RocketMotor& motor)
@@ -43,6 +60,14 @@ class PhysicsEngine {
     RocketMotor& motor_;
 };
 
+/** ForwardEuler Derived Class
+ * This physics engine implents probably the simplest physics simulation
+ * algorithm that exists. To move the simulation forward, it adds the product of
+ * a values derivative and the simulation timestep to the value itself to move
+ * it forward.
+ *
+ * Pretty straightforward.
+ */
 class ForwardEuler : public PhysicsEngine {
    public:
     ForwardEuler(Rocket& rocket, RocketMotor& motor);
@@ -53,6 +78,18 @@ class ForwardEuler : public PhysicsEngine {
     std::shared_ptr<spdlog::logger> euler_logger;
 };
 
+/** ForwardEuler Derived Class
+ * This physics engine implents the fourth order Runge Kutta algorithm.
+ *
+ * This means it calculates the rocket's state in *four* different locations in
+ * space and time, and performs a specific average among these points to result
+ * in a more accurate final rocket state.
+ *
+ * RK4 is certainly more computationally expensive in comparison to
+ * ForwardEuler, but it does provide greater accuracy for the same simulation
+ * timestep.
+ *
+ */
 class RungeKutta : public PhysicsEngine {
    public:
     RungeKutta(Rocket& rocket, RocketMotor& motor)
@@ -70,8 +107,6 @@ class RungeKutta : public PhysicsEngine {
     };
 
     RungeKuttaState calc_state(double tStamp, double tStep, RungeKuttaState k);
-    Vector3d enu2ecef(Vector3d pos_enu);
-    Vector3d ecef2geod(Vector3d ecef);
 };
 
 #endif

--- a/includes/PhysicsEngine.h
+++ b/includes/PhysicsEngine.h
@@ -33,6 +33,10 @@ class PhysicsEngine {
     virtual void march_step(double tStamp, double tStep) = 0;
 
    protected:
+    std::pair<Vector3d, Vector3d> calc_forces_and_moments(double tStamp,
+                                                          Vector3d pos_enu,
+                                                          Vector3d vel_enu);
+
     Quaterniond update_quaternion(Quaterniond q_ornt, Vector3d omega_enu,
                                   double tStep) const;
     Rocket& rocket_;
@@ -65,8 +69,6 @@ class RungeKutta : public PhysicsEngine {
         Vector3d ang_accel;
     };
 
-    Vector3d calc_net_force(double tStamp, Vector3d pos_enu, Vector3d vel_enu);
-    Vector3d calc_net_moment(Vector3d vel_enu, Vector3d pos_enu);
     RungeKuttaState calc_state(double tStamp, double tStep, RungeKuttaState k);
     Vector3d enu2ecef(Vector3d pos_enu);
     Vector3d ecef2geod(Vector3d ecef);

--- a/includes/Rocket.h
+++ b/includes/Rocket.h
@@ -53,7 +53,7 @@ class Rocket {
     Vector3d get_w_dot() const { return w_dot_; };
 
     Vector3d get_f_net() const { return f_net_; };
-    Vector3d get_t_net() const { return t_net_; };
+    Vector3d get_m_net() const { return m_net_; };
 
     double get_structural_mass() const { return structural_mass_; };
     double get_total_mass() const { return total_mass_; };
@@ -90,7 +90,7 @@ class Rocket {
     void set_w_dot(Vector3d vector) { w_dot_ = vector; };
 
     void set_f_net(Vector3d vector) { f_net_ = vector; };
-    void set_t_net(Vector3d vector) { t_net_ = vector; };
+    void set_m_net(Vector3d vector) { m_net_ = vector; };
 
     void set_structural_mass(double mass) { structural_mass_ = mass; };
     void set_total_mass(double mass) { total_mass_ = mass; };
@@ -147,7 +147,7 @@ class Rocket {
 
     // The following are in ENU frame
     Vector3d f_net_{0, 0, 0};  // net force in Netwons
-    Vector3d t_net_{0, 0, 0};  // net torque in Newton*meters
+    Vector3d m_net_{0, 0, 0};  // net moment in Newton*meters
 
     Quaterniond q_ornt_{};  // ENU -> rocket frame quaternion
 

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -386,12 +386,12 @@ void RungeKutta::march_step(double tStamp, double tStep) {
  * state
  *
  * Method performs a basic Euler step on the velocity and angular velocity of
- * the rocket, as well as recalculating forces, accereration, angular
+ * the rocket, as well as recalculating forces, acceleration, angular
  * acceleration, and orientation, using the initial state of the rocket and the
  * data from the state an inputed state
  *
  * @param k The state of the rocket being used to calculate the next state
- * @return RungeKuttaState  Velocity, accereration, angular velocity, and
+ * @return RungeKuttaState  Velocity, acceleration, angular velocity, and
  * angular acceleration at a moment
  */
 RungeKutta::RungeKuttaState RungeKutta::calc_state(double tStamp, double tStep,

--- a/src/Rocket.cpp
+++ b/src/Rocket.cpp
@@ -78,7 +78,6 @@ Vector3d Rocket::enu2r(Vector3d vector) {
 Vector3d Rocket::r2enu(Vector3d vector) {
     Quaterniond p{0, vector.x(), vector.y(), vector.z()};
     p = (q_ornt_ * p) * q_ornt_.conjugate();
-
     return p.vec();
 }
 

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -72,7 +72,7 @@ void Simulation::run(int steps) {
         Vector3d r_ddot = rocket_.enu2r(rocket_.get_r_ddot());
         Vector3d f_net = rocket_.enu2r(rocket_.get_f_net());
         Vector3d w_net = rocket_.enu2r(rocket_.get_w_vect());
-        Vector3d t_net = rocket_.enu2r(rocket_.get_t_net());
+        Vector3d m_net = rocket_.enu2r(rocket_.get_m_net());
 
         double s = q_ornt.w();
         double x = q_ornt.x();
@@ -100,8 +100,8 @@ void Simulation::run(int steps) {
                        f_net.z());
         sim_log->debug("Rocket Frame W-Net: <{}, {}, {}>", w_net.x(), w_net.y(),
                        w_net.z());
-        sim_log->debug("Rocket Frame T-Net: <{}, {}, {}>", t_net.x(), t_net.y(),
-                       t_net.z());
+        sim_log->debug("Rocket Frame T-Net: <{}, {}, {}>", m_net.x(), m_net.y(),
+                       m_net.z());
         sim_log->debug("ROLL: {} PITCH: {} YAW: {}  [deg]", roll, pitch, yaw);
         sim_log->debug("alphaSIM: {}  [deg]", alpha * RAD2DEG);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,10 +64,7 @@ int main() {
     // Cesaroni N5800 Motor
     ThrustCurveSolidMotor motor("thrust_curves/cesaroni_n5800.csv", 9.425);
 
-    // HELLO, RUNGEKUTTA?
-    // RUNGEKUTTA BROKE
     RungeKutta engine(rocket, motor);
-    // UNDERSTANDABLE. HAVE A GREAT DAY
     // ForwardEuler engine(rocket, motor);
 
     CpuState cpu;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,9 +66,9 @@ int main() {
 
     // HELLO, RUNGEKUTTA?
     // RUNGEKUTTA BROKE
-    // RungeKutta engine(rocket, motor);
+    RungeKutta engine(rocket, motor);
     // UNDERSTANDABLE. HAVE A GREAT DAY
-    ForwardEuler engine(rocket, motor);
+    // ForwardEuler engine(rocket, motor);
 
     CpuState cpu;
 


### PR DESCRIPTION
Ended up moving the net force and moment calculations under the base `PhysicsEngine` class instead of the `Rocket` class. Felt that it fit better here as this function is doing physics.

Also fixed the bug introduced in [AV-564] where I had changed the force and moment calculation functions to return the vectors in the rocket body frame instead of ENU. This change just hadn't been reflected in the `RungeKutta::calc_state()` function.

Also fixed another instance of angular acceleration calculations being done in the ENU frame, when they should be done in the rocket body frame. The moment of inertia tensor is only defined int the rocket body frame.

cool stuff