### PR TITLE
[AV-659] Madgwick filter SIL

### DIFF
--- a/data_processing/fsm_debug.py
+++ b/data_processing/fsm_debug.py
@@ -10,15 +10,15 @@ data, events = logutils.ingest_log("logs/silsim_datalog.log")
 timestamps = data['Simulation']['timestamp'] 
 
 start = 0
-stop = 5000
+stop = 10000
 
 state_mult = 200
 
 plt.figure()
-plt.plot(timestamps[start:stop], data['Rocket']['pos_z_enu'][start:stop], color="orange", label="Rocket ENU Altitude [m]")
-plt.plot(timestamps[start:stop], data['Rocket']['vel_z_rf'][start:stop], color="blue", label="Rocket RF Z Velocity [m/s]")
-plt.plot(timestamps[start:stop], data['Rocket']['accel_z_rf'][start:stop], color="yellow", label="Rocket RF Z Acceleration [m/s^2]")
-plt.plot(timestamps[start:stop], state_mult * data['FSM']['state'][start:stop], color='r', linewidth=2.0, label="Rocket State Enum")
+plt.plot(data['Rocket']['timestamp'][start:stop], data['Rocket']['pos_z_enu'][start:stop], color="orange", label="Rocket ENU Altitude [m]")
+plt.plot(data['Rocket']['timestamp'][start:stop], data['Rocket']['vel_z_rf'][start:stop], color="blue", label="Rocket RF Z Velocity [m/s]")
+plt.plot(data['Rocket']['timestamp'][start:stop], data['Rocket']['accel_z_rf'][start:stop], color="yellow", label="Rocket RF Z Acceleration [m/s^2]")
+plt.plot(data['FSM']['timestamp'][start:stop], state_mult * data['FSM']['state'][start:stop], color='r', linewidth=2.0, label="Rocket State Enum")
 
 plt.axhline(0*state_mult, linestyle="--", color='g', linewidth=1.0, label="INIT")
 plt.axhline(1*state_mult, linestyle="--", color='g', linewidth=1.0, label="IDLE")

--- a/data_processing/kalman_debug.py
+++ b/data_processing/kalman_debug.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+import math
 
 import logutils
 
@@ -7,12 +8,59 @@ plt.style.use('dark_background')
 
 data, events = logutils.ingest_log("logs/silsim_datalog.log")
 
-timestamps = data['KalmanFilter']['timestamp'] 
+data['KalmanFilter']['timestamp'] 
+
+def quat_to_euler(x, y, z, w):
+        rad2deg = 180 / np.pi
+
+        t0 = +2.0 * (w * x + y * z)
+        t1 = +1.0 - 2.0 * (x * x + y * y)
+        roll = np.arctan2(t0, t1) * rad2deg
+     
+        t2 = +2.0 * (w * y - z * x)
+        t2 = np.clip(t2, -1.0, +1.0)
+        pitch = np.arcsin(t2) * rad2deg
+     
+        t3 = +2.0 * (w * z + x * y)
+        t4 = +1.0 - 2.0 * (y * y + z * z)
+        yaw = np.arctan2(t3, t4) * rad2deg
+     
+        return roll, pitch, yaw # in degrees
+
+q0 = data['MadgwickAHRS']['q0']
+q1 = data['MadgwickAHRS']['q1']
+q2 = data['MadgwickAHRS']['q2']
+q3 = data['MadgwickAHRS']['q3']
+
+madgwick_roll, madgwick_pitch, madgwick_yaw = quat_to_euler(q1, q2, q3, q0)
 
 plt.figure()
-plt.plot(timestamps, data['KalmanFilter']['Pos'], label="KF Estimated Position [m]")
-plt.plot(timestamps, data['KalmanFilter']['Vel'], label="KF Estimated Velocity [m/s]")
-plt.plot(timestamps, data['KalmanFilter']['Accel'], label="KF Estimated Accel [m/s^2]")
-plt.grid()
+#plt.plot(data['KalmanFilter']['timestamp'], 
+#         data['KalmanFilter']['Pos'], label="KF Estimated Position [m]")
+#
+#plt.plot(data['KalmanFilter']['timestamp'], 
+#         data['KalmanFilter']['Vel'], label="KF Estimated Velocity [m/s]")
+#
+#plt.plot(data['KalmanFilter']['timestamp'], 
+#         data['KalmanFilter']['Accel'], label="KF Estimated Accel [m/s^2]")
+
+plt.subplot(311)
+plt.plot(data['MadgwickAHRS']['timestamp'], madgwick_yaw, label="Estimated Yaw [deg]")
+plt.plot(data['Simulation']['timestamp'], data['Simulation']['yaw'],
+         linestyle='--', color='r', label="Yaw Truth")
 plt.legend()
+
+plt.subplot(312)
+plt.plot(data['MadgwickAHRS']['timestamp'], madgwick_pitch, label="Estimated Pitch [deg]")
+plt.plot(data['Simulation']['timestamp'], data['Simulation']['pitch'],
+         linestyle='--', color='r', label="Pitch Truth")
+plt.legend()
+
+plt.subplot(313)
+plt.plot(data['MadgwickAHRS']['timestamp'], madgwick_roll, label="Estimated Roll [deg]")
+plt.plot(data['Simulation']['timestamp'], data['Simulation']['roll'],
+         linestyle='--', color='r', label="Roll Truth")
+plt.legend()
+
 plt.show()
+#plt.savefig("kalman_debug.png", dpi=400)

--- a/data_processing/magnetometer_debug.py
+++ b/data_processing/magnetometer_debug.py
@@ -1,0 +1,21 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+import logutils
+
+plt.style.use('dark_background')
+
+data, events = logutils.ingest_log("logs/silsim_datalog.log")
+
+timestamps = data['Simulation']['timestamp'] 
+
+plt.figure()
+#plt.plot(timestamps, data['Simulation']['roll'], label="Simulation Roll")
+#plt.plot(timestamps, data['Simulation']['pitch'], label="Simulation Pitch")
+#plt.plot(timestamps, data['Simulation']['yaw'], label="Simulation Yaw")
+plt.plot(timestamps, data['Magnetometer:LSM9_magnetometer']['mag_x_r'], label="Mag X RF")
+plt.plot(timestamps, data['Magnetometer:LSM9_magnetometer']['mag_y_rf'], label="Mag Y RF")
+plt.plot(timestamps, data['Magnetometer:LSM9_magnetometer']['mag_z_rf'], label="Mag Z RF")
+plt.grid()
+plt.legend()
+plt.show()

--- a/data_processing/sensor_debug.py
+++ b/data_processing/sensor_debug.py
@@ -9,10 +9,66 @@ data, events = logutils.ingest_log("logs/silsim_datalog.log")
 
 timestamps = data['Simulation']['timestamp'] 
 
+#plt.figure()
+#plt.plot(timestamps, data['Barometer:MS5611_barometer']['baro_altitude'], label="MS5611 Baro Altitude [m]")
+#plt.plot(timestamps, data['Rocket']['pos_z_enu'], linestyle="--", label="True Rocket Altitude [m]")
+#plt.plot(timestamps, data['Thermometer:MS5611_thermometer']['temperature'], label="MS5611 Baro Temperature [K]")
+#plt.grid()
+#plt.legend()
+#plt.show()
+
 plt.figure()
-plt.plot(timestamps, data['Barometer:MS5611_barometer']['baro_altitude'], label="MS5611 Baro Altitude [m]")
-plt.plot(timestamps, data['Rocket']['pos_z_enu'], linestyle="--", label="True Rocket Altitude [m]")
-plt.plot(timestamps, data['Thermometer:MS5611_thermometer']['temperature'], label="MS5611 Baro Temperature [K]")
-plt.grid()
+plt.subplot(611)
+plt.plot(data['Accelerometer:LSM9_accel']['timestamp'],
+         data['Accelerometer:LSM9_accel']['accel_x_rf'],
+         color='g', linewidth=0.8, label="X Accel RF LSM9DS1 [m/s^2]")
+plt.plot(data['Rocket']['timestamp'], 
+         data['Rocket']['accel_x_rf'], 
+         color='r', linestyle='--', linewidth=1.0, label="X Accel RF Truth [m/s^2]")
 plt.legend()
+plt.subplot(612)
+plt.plot(data['Accelerometer:LSM9_accel']['timestamp'],
+         data['Accelerometer:LSM9_accel']['accel_y_rf'],
+         color='g', linewidth=0.8, label="Y Accel RF LSM9DS1 [m/s^2]")
+plt.plot(data['Rocket']['timestamp'], 
+         data['Rocket']['accel_y_rf'], 
+         color='r', linestyle='--', linewidth=1.0, label="Y Accel RF Truth [m/s^2]")
+plt.legend()
+plt.subplot(613)
+plt.plot(data['Accelerometer:LSM9_accel']['timestamp'],
+         data['Accelerometer:LSM9_accel']['accel_z_rf'],
+         color='g', linewidth=0.8, label="Z Accel RF LSM9DS1 [m/s^2]")
+plt.plot(data['Rocket']['timestamp'], 
+         data['Rocket']['accel_z_rf'], 
+         color='r', linestyle='--', linewidth=1.0, label="Z Accel RF Truth [m/s^2]")
+plt.legend()
+
+plt.subplot(614)
+plt.plot(data['Gyroscope:LSM9_gyro']['timestamp'],
+         data['Gyroscope:LSM9_gyro']['gyro_x_rf'],
+         color='g', linewidth=0.8, label="X Ang. Vel RF LSM9DS1 [rad/sec]")
+plt.plot(data['Rocket']['timestamp'],
+         data['Rocket']['ang_vel_x_rf'],
+         color='r', linestyle='--', linewidth=1.0, 
+         label="X Ang. Velocity RF Truth [rad/sec]")
+plt.legend()
+plt.subplot(615)
+plt.plot(data['Gyroscope:LSM9_gyro']['timestamp'],
+         data['Gyroscope:LSM9_gyro']['gyro_y_rf'],
+         color='g', linewidth=0.8, label="Y Ang. Vel RF LSM9DS1 [rad/sec]")
+plt.plot(data['Rocket']['timestamp'],
+         data['Rocket']['ang_vel_y_rf'],
+         color='r', linestyle='--', linewidth=1.0, 
+         label="Y Ang. Velocity RF Truth [rad/sec]")
+plt.legend()
+plt.subplot(616)
+plt.plot(data['Gyroscope:LSM9_gyro']['timestamp'],
+         data['Gyroscope:LSM9_gyro']['gyro_z_rf'],
+         color='g', linewidth=0.8, label="Z Ang. Vel RF LSM9DS1 [rad/sec]")
+plt.plot(data['Rocket']['timestamp'],
+         data['Rocket']['ang_vel_z_rf'],
+         color='r', linestyle='--', linewidth=1.0, 
+         label="Z Ang. Velocity RF Truth [rad/sec]")
+plt.legend()
+
 plt.show()

--- a/flight_src/mcu/lib/emulation/EMU.cpp
+++ b/flight_src/mcu/lib/emulation/EMU.cpp
@@ -12,7 +12,8 @@
 #include "SPI.h"
 #include "SparkFunLSM9DS1.h"
 #include "SD.h"
-// #include <iostream>
+
+#include <iostream>
 
 
 //Define Table for resolutions (for aRes, gRes, mRes)
@@ -229,6 +230,10 @@ void LSM9DS1::readMag() {
     mx = scaled.x();
     my = scaled.y();
     mz = scaled.z();
+
+    std::cout << "Debug LSM9DS1::readMag()  "; 
+    //std::cout << mx << "," << my << "," << mz << std::endl;
+    std::cout << data.x() << "," << data.y() << "," << data.z() << std::endl;
 }
 float LSM9DS1::calcMag(int16_t mag) {
     return mag * mRes;

--- a/flight_src/mcu/lib/emulation/EMU.cpp
+++ b/flight_src/mcu/lib/emulation/EMU.cpp
@@ -154,7 +154,6 @@ void LSM9DS1::readAccel() {
     Eigen::Vector3d data;
     global_context->accelerometer_pointer->get_data(data);
 
-
     double clamp_val = 0;
     if(aRes == SENSITIVITY_ACCELEROMETER_2){
         clamp_val = 2;
@@ -163,6 +162,8 @@ void LSM9DS1::readAccel() {
     } else if(aRes == SENSITIVITY_ACCELEROMETER_8){
         clamp_val = 8;
     } else if(aRes == SENSITIVITY_ACCELEROMETER_16){
+        clamp_val = 16;
+    } else {
         clamp_val = 16;
     }
 
@@ -230,10 +231,6 @@ void LSM9DS1::readMag() {
     mx = scaled.x();
     my = scaled.y();
     mz = scaled.z();
-
-    std::cout << "Debug LSM9DS1::readMag()  "; 
-    //std::cout << mx << "," << my << "," << mz << std::endl;
-    std::cout << data.x() << "," << data.y() << "," << data.z() << std::endl;
 }
 float LSM9DS1::calcMag(int16_t mag) {
     return mag * mRes;

--- a/flight_src/mcu/lib/teensyShared/MadgwickAHRS.cpp
+++ b/flight_src/mcu/lib/teensyShared/MadgwickAHRS.cpp
@@ -1,5 +1,5 @@
 /**
- * @file        MadgwickAHRS.h
+ * @file        MadgwickAHRS.cpp
  * @authors     Ayberk Yaraneri
  *
  * @brief   A wrapper class that implements the Madwick AHRS filter for attitude estimation.
@@ -11,54 +11,253 @@
  *
  */
 
-#ifndef MADGWICK_AHRS_H
-#define MADGWICK_AHRS_H
+#include "MadgwickAHRS.h"
 
-#include "sensors.h"
+#include <iostream>
 
-#include "GlobalVars.h"
+#include <math.h>
 
-#define sampleFreq	100.0f		// sample frequency in Hz
-#define betaDef		0.1f		// 2 * proportional gain
+void MadgwickAHRS::MadgwickAHRSupdate() {
 
-class MadgwickAHRS {
-    public:
-        MadgwickAHRS(pointers* ptr) {
-            pointer_struct_ = ptr;
+    // Fetch data from sensors
+    chMtxLock(dataMutex_lowG_);
+    float gx = lowG_data_ptr_->gx;
+    float gy = lowG_data_ptr_->gy;
+    float gz = lowG_data_ptr_->gz;
 
-            state_data_ptr_ = &pointer_struct_->stateData;
-            lowG_data_ptr_ = &pointer_struct_->sensorDataPointer->lowG_data;
-            dataMutex_lowG_ = &pointer_struct_->dataloggerTHDVarsPointer.dataMutex_lowG;
-            dataMutex_state_ = &pointer_struct_->dataloggerTHDVarsPointer.dataMutex_state;
+    float ax = lowG_data_ptr_->ax;
+    float ay = lowG_data_ptr_->ay;
+    float az = lowG_data_ptr_->az;
 
-            // SILSIM Data Logging
-            madgwick_logger_ = std::make_shared<spdlog::logger>("MadgwickAHRS", silsim_datalog_sink);
-            madgwick_logger_->info("DATALOG_FORMAT," + datalog_format_string);
-        };
+    float mx = lowG_data_ptr_->mx;
+    float my = lowG_data_ptr_->my;
+    float mz = lowG_data_ptr_->mz;
+    chMtxUnlock(dataMutex_lowG_);
 
-        void MadgwickAHRSupdate();
-        void MadgwickAHRSupdateIMU();
 
-        // SILSIM Data Logging
-        void log_madgwick_state(double tStamp);
+	float recipNorm;
+	float s0, s1, s2, s3;
+	float qDot1, qDot2, qDot3, qDot4;
+	float hx, hy;
+	float _2q0mx, _2q0my, _2q0mz, _2q1mx, _2bx, _2bz, _4bx, _4bz, _2q0, _2q1, _2q2, _2q3, _2q0q2, _2q2q3, q0q0, q0q1, q0q2, q0q3, q1q1, q1q2, q1q3, q2q2, q2q3, q3q3;
 
-    private:
-        pointers* pointer_struct_;
-        StateData* state_data_ptr_;
-        LowGData* lowG_data_ptr_;
+	// Use IMU algorithm if magnetometer measurement invalid (avoids NaN in magnetometer normalisation)
+	if((mx == 0.0f) && (my == 0.0f) && (mz == 0.0f)) {
+		MadgwickAHRSupdateIMU();
+		return;
+	}
 
-        mutex_t* dataMutex_lowG_;
-        mutex_t* dataMutex_state_;
+	// Rate of change of quaternion from gyroscope
+	qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
+	qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
+	qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
+	qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
 
-        float beta_ = betaDef;
-        float q0 = 1.0, q1 = 0.0, q2 = 0.0, q3 = 0.0;
+	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) {
 
-        float invSqrt(float x);
+		// Normalise accelerometer measurement
+		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
+		ax *= recipNorm;
+		ay *= recipNorm;
+		az *= recipNorm;   
 
-        // SILSIM Data Logging
-        std::shared_ptr<spdlog::logger> madgwick_logger_;
-        std::string datalog_format_string = 
-            "timestamp,q0,q1,q2,q3";
-};
+		// Normalise magnetometer measurement
+		recipNorm = invSqrt(mx * mx + my * my + mz * mz);
+		mx *= recipNorm;
+		my *= recipNorm;
+		mz *= recipNorm;
 
-#endif // MADGWICK_AHRS_H
+		// Auxiliary variables to avoid repeated arithmetic
+		_2q0mx = 2.0f * q0 * mx;
+		_2q0my = 2.0f * q0 * my;
+		_2q0mz = 2.0f * q0 * mz;
+		_2q1mx = 2.0f * q1 * mx;
+		_2q0 = 2.0f * q0;
+		_2q1 = 2.0f * q1;
+		_2q2 = 2.0f * q2;
+		_2q3 = 2.0f * q3;
+		_2q0q2 = 2.0f * q0 * q2;
+		_2q2q3 = 2.0f * q2 * q3;
+		q0q0 = q0 * q0;
+		q0q1 = q0 * q1;
+		q0q2 = q0 * q2;
+		q0q3 = q0 * q3;
+		q1q1 = q1 * q1;
+		q1q2 = q1 * q2;
+		q1q3 = q1 * q3;
+		q2q2 = q2 * q2;
+		q2q3 = q2 * q3;
+		q3q3 = q3 * q3;
+
+		// Reference direction of Earth's magnetic field
+		hx = mx * q0q0 - _2q0my * q3 + _2q0mz * q2 + mx * q1q1 + _2q1 * my * q2 + _2q1 * mz * q3 - mx * q2q2 - mx * q3q3;
+		hy = _2q0mx * q3 + my * q0q0 - _2q0mz * q1 + _2q1mx * q2 - my * q1q1 + my * q2q2 + _2q2 * mz * q3 - my * q3q3;
+		_2bx = sqrt(hx * hx + hy * hy);
+		_2bz = -_2q0mx * q2 + _2q0my * q1 + mz * q0q0 + _2q1mx * q3 - mz * q1q1 + _2q2 * my * q3 - mz * q2q2 + mz * q3q3;
+		_4bx = 2.0f * _2bx;
+		_4bz = 2.0f * _2bz;
+
+		// Gradient decent algorithm corrective step
+		s0 = -_2q2 * (2.0f * q1q3 - _2q0q2 - ax) + _2q1 * (2.0f * q0q1 + _2q2q3 - ay) - _2bz * q2 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q3 + _2bz * q1) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q2 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+		s1 = _2q3 * (2.0f * q1q3 - _2q0q2 - ax) + _2q0 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q1 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + _2bz * q3 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q2 + _2bz * q0) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q3 - _4bz * q1) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+		s2 = -_2q0 * (2.0f * q1q3 - _2q0q2 - ax) + _2q3 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q2 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + (-_4bx * q2 - _2bz * q0) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q1 + _2bz * q3) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q0 - _4bz * q2) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+		s3 = _2q1 * (2.0f * q1q3 - _2q0q2 - ax) + _2q2 * (2.0f * q0q1 + _2q2q3 - ay) + (-_4bx * q3 + _2bz * q1) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q0 + _2bz * q2) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q1 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
+		s0 *= recipNorm;
+		s1 *= recipNorm;
+		s2 *= recipNorm;
+		s3 *= recipNorm;
+
+		// Apply feedback step
+		qDot1 -= beta_ * s0;
+		qDot2 -= beta_ * s1;
+		qDot3 -= beta_ * s2;
+		qDot4 -= beta_ * s3;
+	}
+
+	// Integrate rate of change of quaternion to yield quaternion
+	q0 += qDot1 * (1.0f / sampleFreq);
+	q1 += qDot2 * (1.0f / sampleFreq);
+	q2 += qDot3 * (1.0f / sampleFreq);
+	q3 += qDot4 * (1.0f / sampleFreq);
+
+	// Normalise quaternion
+	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+	q0 *= recipNorm;
+	q1 *= recipNorm;
+	q2 *= recipNorm;
+	q3 *= recipNorm;
+
+
+    // Write orientation estimate to stateData struct
+    chMtxLock(dataMutex_state_);
+    state_data_ptr_->state_q0 = q0;
+    state_data_ptr_->state_q1 = q1;
+    state_data_ptr_->state_q2 = q2;
+    state_data_ptr_->state_q3 = q3;
+    state_data_ptr_->timeStamp_state = chVTGetSystemTime();
+    chMtxUnlock(dataMutex_state_);
+}
+
+
+void MadgwickAHRS::MadgwickAHRSupdateIMU() {
+
+    // Fetch data from sensors
+    chMtxLock(dataMutex_lowG_);
+    float gx = lowG_data_ptr_->gx;
+    float gy = lowG_data_ptr_->gy;
+    float gz = lowG_data_ptr_->gz;
+
+    float ax = lowG_data_ptr_->ax;
+    float ay = lowG_data_ptr_->ay;
+    float az = lowG_data_ptr_->az;
+    chMtxUnlock(dataMutex_lowG_);
+
+	float recipNorm;
+	float s0, s1, s2, s3;
+	float qDot1, qDot2, qDot3, qDot4;
+	float _2q0, _2q1, _2q2, _2q3, _4q0, _4q1, _4q2 ,_8q1, _8q2, q0q0, q1q1, q2q2, q3q3;
+
+	// Rate of change of quaternion from gyroscope
+	qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
+	qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
+	qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
+	qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
+
+	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) {
+
+		// Normalise accelerometer measurement
+		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
+		ax *= recipNorm;
+		ay *= recipNorm;
+		az *= recipNorm;   
+
+		// Auxiliary variables to avoid repeated arithmetic
+		_2q0 = 2.0f * q0;
+		_2q1 = 2.0f * q1;
+		_2q2 = 2.0f * q2;
+		_2q3 = 2.0f * q3;
+		_4q0 = 4.0f * q0;
+		_4q1 = 4.0f * q1;
+		_4q2 = 4.0f * q2;
+		_8q1 = 8.0f * q1;
+		_8q2 = 8.0f * q2;
+		q0q0 = q0 * q0;
+		q1q1 = q1 * q1;
+		q2q2 = q2 * q2;
+		q3q3 = q3 * q3;
+
+		// Gradient decent algorithm corrective step
+		s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
+		s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1 - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
+		s2 = 4.0f * q0q0 * q2 + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
+		s3 = 4.0f * q1q1 * q3 - _2q1 * ax + 4.0f * q2q2 * q3 - _2q2 * ay;
+		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
+		s0 *= recipNorm;
+		s1 *= recipNorm;
+		s2 *= recipNorm;
+		s3 *= recipNorm;
+
+		// Apply feedback step
+		qDot1 -= beta_ * s0;
+		qDot2 -= beta_ * s1;
+		qDot3 -= beta_ * s2;
+		qDot4 -= beta_ * s3;
+	}
+
+	// Integrate rate of change of quaternion to yield quaternion
+	q0 += qDot1 * (1.0f / sampleFreq);
+	q1 += qDot2 * (1.0f / sampleFreq);
+	q2 += qDot3 * (1.0f / sampleFreq);
+	q3 += qDot4 * (1.0f / sampleFreq);
+
+	// Normalise quaternion
+	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+	q0 *= recipNorm;
+	q1 *= recipNorm;
+	q2 *= recipNorm;
+	q3 *= recipNorm;
+
+
+    // Write orientation estimate to stateData struct
+    chMtxLock(dataMutex_state_);
+    state_data_ptr_->state_q0 = q0;
+    state_data_ptr_->state_q1 = q1;
+    state_data_ptr_->state_q2 = q2;
+    state_data_ptr_->state_q3 = q3;
+    state_data_ptr_->timeStamp_state = chVTGetSystemTime();
+    chMtxUnlock(dataMutex_state_);
+}
+
+
+// Fast inverse square-root
+// See: http://en.wikipedia.org/wiki/Fast_inverse_square_root
+
+float MadgwickAHRS::invSqrt(float x) {
+	float halfx = 0.5f * x;
+	float y = x;
+	long i = *(long*)&y;
+	i = 0x5f3759df - (i>>1);
+	y = *(float*)&i;
+	y = y * (1.5f - (halfx * y * y));
+	return y;
+}
+
+// SILSIM Data Logging
+void MadgwickAHRS::log_madgwick_state(double tStamp) {
+    if (madgwick_logger_) {
+
+        std::stringstream datalog_ss;
+
+        datalog_ss << "DATA,"
+                   << tStamp << ","
+                   << q0 << ","
+                   << q1 << ","
+                   << q2 << ","
+                   << q3; 
+
+        madgwick_logger_->info(datalog_ss.str());
+    }
+}

--- a/flight_src/mcu/lib/teensyShared/MadgwickAHRS.cpp
+++ b/flight_src/mcu/lib/teensyShared/MadgwickAHRS.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file        MadgwickAHRS.h
+ * @authors     Ayberk Yaraneri
+ *
+ * @brief   A wrapper class that implements the Madwick AHRS filter for attitude estimation.
+ *
+ * This class simply wraps the functionality of the Madgwick AHRS filter in a C++ class.
+ *
+ * Implementation of Madgwick's IMU and AHRS algorithms:
+ * http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms
+ *
+ */
+
+#ifndef MADGWICK_AHRS_H
+#define MADGWICK_AHRS_H
+
+#include "sensors.h"
+
+#include "GlobalVars.h"
+
+#define sampleFreq	100.0f		// sample frequency in Hz
+#define betaDef		0.1f		// 2 * proportional gain
+
+class MadgwickAHRS {
+    public:
+        MadgwickAHRS(pointers* ptr) {
+            pointer_struct_ = ptr;
+
+            state_data_ptr_ = &pointer_struct_->stateData;
+            lowG_data_ptr_ = &pointer_struct_->sensorDataPointer->lowG_data;
+            dataMutex_lowG_ = &pointer_struct_->dataloggerTHDVarsPointer.dataMutex_lowG;
+            dataMutex_state_ = &pointer_struct_->dataloggerTHDVarsPointer.dataMutex_state;
+
+            // SILSIM Data Logging
+            madgwick_logger_ = std::make_shared<spdlog::logger>("MadgwickAHRS", silsim_datalog_sink);
+            madgwick_logger_->info("DATALOG_FORMAT," + datalog_format_string);
+        };
+
+        void MadgwickAHRSupdate();
+        void MadgwickAHRSupdateIMU();
+
+        // SILSIM Data Logging
+        void log_madgwick_state(double tStamp);
+
+    private:
+        pointers* pointer_struct_;
+        StateData* state_data_ptr_;
+        LowGData* lowG_data_ptr_;
+
+        mutex_t* dataMutex_lowG_;
+        mutex_t* dataMutex_state_;
+
+        float beta_ = betaDef;
+        float q0 = 1.0, q1 = 0.0, q2 = 0.0, q3 = 0.0;
+
+        float invSqrt(float x);
+
+        // SILSIM Data Logging
+        std::shared_ptr<spdlog::logger> madgwick_logger_;
+        std::string datalog_format_string = 
+            "timestamp,q0,q1,q2,q3";
+};
+
+#endif // MADGWICK_AHRS_H

--- a/flight_src/mcu/lib/teensyShared/MadgwickAHRS.h
+++ b/flight_src/mcu/lib/teensyShared/MadgwickAHRS.h
@@ -1,0 +1,268 @@
+/**
+ * @file        MadgwickAHRS.cpp
+ * @authors     Ayberk Yaraneri
+ *
+ * @brief   A wrapper class that implements the Madwick AHRS filter for attitude estimation.
+ *
+ * This class simply wraps the functionality of the Madgwick AHRS filter in a C++ class.
+ *
+ * Implementation of Madgwick's IMU and AHRS algorithms:
+ * http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms
+ *
+ */
+
+#include "MadgwickAHRS.cpp"
+
+#include <math.h>
+
+void MadgwickAHRS::MadgwickAHRSupdate() {
+
+    // Fetch data from sensors
+    chMtxLock(dataMutex_lowG_);
+    float gx = lowG_data_ptr_->gx;
+    float gy = lowG_data_ptr_->gy;
+    float gz = lowG_data_ptr_->gz;
+
+    float ax = lowG_data_ptr_->ax;
+    float ay = lowG_data_ptr_->ay;
+    float az = lowG_data_ptr_->az;
+
+    float mx = lowG_data_ptr_->mx;
+    float my = lowG_data_ptr_->my;
+    float mz = lowG_data_ptr_->mz;
+    chMtxUnlock(dataMutex_lowG_);
+
+
+	float recipNorm;
+	float s0, s1, s2, s3;
+	float qDot1, qDot2, qDot3, qDot4;
+	float hx, hy;
+	float _2q0mx, _2q0my, _2q0mz, _2q1mx, _2bx, _2bz, _4bx, _4bz, _2q0, _2q1, _2q2, _2q3, _2q0q2, _2q2q3, q0q0, q0q1, q0q2, q0q3, q1q1, q1q2, q1q3, q2q2, q2q3, q3q3;
+
+	// Use IMU algorithm if magnetometer measurement invalid (avoids NaN in magnetometer normalisation)
+	if((mx == 0.0f) && (my == 0.0f) && (mz == 0.0f)) {
+		MadgwickAHRSupdateIMU();
+        std::cout << "Debug1: "; 
+        std::cout << mx << "," << my << "," << mz << std::endl;
+		return;
+	}
+
+	// Rate of change of quaternion from gyroscope
+	qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
+	qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
+	qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
+	qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
+
+	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) {
+
+		// Normalise accelerometer measurement
+		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
+		ax *= recipNorm;
+		ay *= recipNorm;
+		az *= recipNorm;   
+
+		// Normalise magnetometer measurement
+		recipNorm = invSqrt(mx * mx + my * my + mz * mz);
+		mx *= recipNorm;
+		my *= recipNorm;
+		mz *= recipNorm;
+
+		// Auxiliary variables to avoid repeated arithmetic
+		_2q0mx = 2.0f * q0 * mx;
+		_2q0my = 2.0f * q0 * my;
+		_2q0mz = 2.0f * q0 * mz;
+		_2q1mx = 2.0f * q1 * mx;
+		_2q0 = 2.0f * q0;
+		_2q1 = 2.0f * q1;
+		_2q2 = 2.0f * q2;
+		_2q3 = 2.0f * q3;
+		_2q0q2 = 2.0f * q0 * q2;
+		_2q2q3 = 2.0f * q2 * q3;
+		q0q0 = q0 * q0;
+		q0q1 = q0 * q1;
+		q0q2 = q0 * q2;
+		q0q3 = q0 * q3;
+		q1q1 = q1 * q1;
+		q1q2 = q1 * q2;
+		q1q3 = q1 * q3;
+		q2q2 = q2 * q2;
+		q2q3 = q2 * q3;
+		q3q3 = q3 * q3;
+
+		// Reference direction of Earth's magnetic field
+		hx = mx * q0q0 - _2q0my * q3 + _2q0mz * q2 + mx * q1q1 + _2q1 * my * q2 + _2q1 * mz * q3 - mx * q2q2 - mx * q3q3;
+		hy = _2q0mx * q3 + my * q0q0 - _2q0mz * q1 + _2q1mx * q2 - my * q1q1 + my * q2q2 + _2q2 * mz * q3 - my * q3q3;
+		_2bx = sqrt(hx * hx + hy * hy);
+		_2bz = -_2q0mx * q2 + _2q0my * q1 + mz * q0q0 + _2q1mx * q3 - mz * q1q1 + _2q2 * my * q3 - mz * q2q2 + mz * q3q3;
+		_4bx = 2.0f * _2bx;
+		_4bz = 2.0f * _2bz;
+
+		// Gradient decent algorithm corrective step
+		s0 = -_2q2 * (2.0f * q1q3 - _2q0q2 - ax) + _2q1 * (2.0f * q0q1 + _2q2q3 - ay) - _2bz * q2 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q3 + _2bz * q1) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q2 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+		s1 = _2q3 * (2.0f * q1q3 - _2q0q2 - ax) + _2q0 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q1 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + _2bz * q3 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q2 + _2bz * q0) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q3 - _4bz * q1) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+		s2 = -_2q0 * (2.0f * q1q3 - _2q0q2 - ax) + _2q3 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q2 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + (-_4bx * q2 - _2bz * q0) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q1 + _2bz * q3) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q0 - _4bz * q2) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+		s3 = _2q1 * (2.0f * q1q3 - _2q0q2 - ax) + _2q2 * (2.0f * q0q1 + _2q2q3 - ay) + (-_4bx * q3 + _2bz * q1) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q0 + _2bz * q2) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q1 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
+		s0 *= recipNorm;
+		s1 *= recipNorm;
+		s2 *= recipNorm;
+		s3 *= recipNorm;
+
+		// Apply feedback step
+		qDot1 -= beta_ * s0;
+		qDot2 -= beta_ * s1;
+		qDot3 -= beta_ * s2;
+		qDot4 -= beta_ * s3;
+	}
+    else {
+        std::cout << "Debug2" << std::endl;
+    }
+
+	// Integrate rate of change of quaternion to yield quaternion
+	q0 += qDot1 * (1.0f / sampleFreq);
+	q1 += qDot2 * (1.0f / sampleFreq);
+	q2 += qDot3 * (1.0f / sampleFreq);
+	q3 += qDot4 * (1.0f / sampleFreq);
+
+	// Normalise quaternion
+	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+	q0 *= recipNorm;
+	q1 *= recipNorm;
+	q2 *= recipNorm;
+	q3 *= recipNorm;
+
+
+    // Write orientation estimate to stateData struct
+    chMtxLock(dataMutex_state_);
+    state_data_ptr_->state_q0 = q0;
+    state_data_ptr_->state_q1 = q1;
+    state_data_ptr_->state_q2 = q2;
+    state_data_ptr_->state_q3 = q3;
+    chMtxUnlock(dataMutex_state_);
+}
+
+
+void MadgwickAHRS::MadgwickAHRSupdateIMU() {
+
+    // Fetch data from sensors
+    chMtxLock(dataMutex_lowG_);
+    float gx = lowG_data_ptr_->gx;
+    float gy = lowG_data_ptr_->gy;
+    float gz = lowG_data_ptr_->gz;
+
+    float ax = lowG_data_ptr_->ax;
+    float ay = lowG_data_ptr_->ay;
+    float az = lowG_data_ptr_->az;
+
+    float mx = lowG_data_ptr_->mx;
+    float my = lowG_data_ptr_->my;
+    float mz = lowG_data_ptr_->mz;
+    chMtxUnlock(dataMutex_lowG_);
+
+	float recipNorm;
+	float s0, s1, s2, s3;
+	float qDot1, qDot2, qDot3, qDot4;
+	float _2q0, _2q1, _2q2, _2q3, _4q0, _4q1, _4q2 ,_8q1, _8q2, q0q0, q1q1, q2q2, q3q3;
+
+	// Rate of change of quaternion from gyroscope
+	qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
+	qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
+	qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
+	qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
+
+	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) {
+
+		// Normalise accelerometer measurement
+		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
+		ax *= recipNorm;
+		ay *= recipNorm;
+		az *= recipNorm;   
+
+		// Auxiliary variables to avoid repeated arithmetic
+		_2q0 = 2.0f * q0;
+		_2q1 = 2.0f * q1;
+		_2q2 = 2.0f * q2;
+		_2q3 = 2.0f * q3;
+		_4q0 = 4.0f * q0;
+		_4q1 = 4.0f * q1;
+		_4q2 = 4.0f * q2;
+		_8q1 = 8.0f * q1;
+		_8q2 = 8.0f * q2;
+		q0q0 = q0 * q0;
+		q1q1 = q1 * q1;
+		q2q2 = q2 * q2;
+		q3q3 = q3 * q3;
+
+		// Gradient decent algorithm corrective step
+		s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
+		s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1 - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
+		s2 = 4.0f * q0q0 * q2 + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
+		s3 = 4.0f * q1q1 * q3 - _2q1 * ax + 4.0f * q2q2 * q3 - _2q2 * ay;
+		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
+		s0 *= recipNorm;
+		s1 *= recipNorm;
+		s2 *= recipNorm;
+		s3 *= recipNorm;
+
+		// Apply feedback step
+		qDot1 -= beta_ * s0;
+		qDot2 -= beta_ * s1;
+		qDot3 -= beta_ * s2;
+		qDot4 -= beta_ * s3;
+	}
+
+	// Integrate rate of change of quaternion to yield quaternion
+	q0 += qDot1 * (1.0f / sampleFreq);
+	q1 += qDot2 * (1.0f / sampleFreq);
+	q2 += qDot3 * (1.0f / sampleFreq);
+	q3 += qDot4 * (1.0f / sampleFreq);
+
+	// Normalise quaternion
+	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+	q0 *= recipNorm;
+	q1 *= recipNorm;
+	q2 *= recipNorm;
+	q3 *= recipNorm;
+
+
+    // Write orientation estimate to stateData struct
+    chMtxLock(dataMutex_state_);
+    state_data_ptr_->state_q0 = q0;
+    state_data_ptr_->state_q1 = q1;
+    state_data_ptr_->state_q2 = q2;
+    state_data_ptr_->state_q3 = q3;
+    chMtxUnlock(dataMutex_state_);
+}
+
+
+// Fast inverse square-root
+// See: http://en.wikipedia.org/wiki/Fast_inverse_square_root
+
+float MadgwickAHRS::invSqrt(float x) {
+	float halfx = 0.5f * x;
+	float y = x;
+	long i = *(long*)&y;
+	i = 0x5f3759df - (i>>1);
+	y = *(float*)&i;
+	y = y * (1.5f - (halfx * y * y));
+	return y;
+}
+
+// SILSIM Data Logging
+void MadgwickAHRS::log_madgwick_state(double tStamp) {
+    if (madgwick_logger_) {
+
+        std::stringstream datalog_ss;
+
+        datalog_ss << "DATA,"
+                   << tStamp << ","
+                   << q0 << ","
+                   << q1 << ","
+                   << q2 << ","
+                   << q3; 
+
+        madgwick_logger_->info(datalog_ss.str());
+    }
+}

--- a/flight_src/mcu/lib/teensyShared/MadgwickAHRS.h
+++ b/flight_src/mcu/lib/teensyShared/MadgwickAHRS.h
@@ -1,5 +1,5 @@
 /**
- * @file        MadgwickAHRS.cpp
+ * @file        MadgwickAHRS.h
  * @authors     Ayberk Yaraneri
  *
  * @brief   A wrapper class that implements the Madwick AHRS filter for attitude estimation.
@@ -11,258 +11,54 @@
  *
  */
 
-#include "MadgwickAHRS.cpp"
+#ifndef MADGWICK_AHRS_H
+#define MADGWICK_AHRS_H
 
-#include <math.h>
+#include "sensors.h"
 
-void MadgwickAHRS::MadgwickAHRSupdate() {
+#include "GlobalVars.h"
 
-    // Fetch data from sensors
-    chMtxLock(dataMutex_lowG_);
-    float gx = lowG_data_ptr_->gx;
-    float gy = lowG_data_ptr_->gy;
-    float gz = lowG_data_ptr_->gz;
+#define sampleFreq	100.0f		// sample frequency in Hz
+#define betaDef		0.1f		// 2 * proportional gain
 
-    float ax = lowG_data_ptr_->ax;
-    float ay = lowG_data_ptr_->ay;
-    float az = lowG_data_ptr_->az;
+class MadgwickAHRS {
+    public:
+        MadgwickAHRS(pointers* ptr) {
+            pointer_struct_ = ptr;
 
-    float mx = lowG_data_ptr_->mx;
-    float my = lowG_data_ptr_->my;
-    float mz = lowG_data_ptr_->mz;
-    chMtxUnlock(dataMutex_lowG_);
+            state_data_ptr_ = &pointer_struct_->stateData;
+            lowG_data_ptr_ = &pointer_struct_->sensorDataPointer->lowG_data;
+            dataMutex_lowG_ = &pointer_struct_->dataloggerTHDVarsPointer.dataMutex_lowG;
+            dataMutex_state_ = &pointer_struct_->dataloggerTHDVarsPointer.dataMutex_state;
 
+            // SILSIM Data Logging
+            madgwick_logger_ = std::make_shared<spdlog::logger>("MadgwickAHRS", silsim_datalog_sink);
+            madgwick_logger_->info("DATALOG_FORMAT," + datalog_format_string);
+        };
 
-	float recipNorm;
-	float s0, s1, s2, s3;
-	float qDot1, qDot2, qDot3, qDot4;
-	float hx, hy;
-	float _2q0mx, _2q0my, _2q0mz, _2q1mx, _2bx, _2bz, _4bx, _4bz, _2q0, _2q1, _2q2, _2q3, _2q0q2, _2q2q3, q0q0, q0q1, q0q2, q0q3, q1q1, q1q2, q1q3, q2q2, q2q3, q3q3;
+        void MadgwickAHRSupdate();
+        void MadgwickAHRSupdateIMU();
 
-	// Use IMU algorithm if magnetometer measurement invalid (avoids NaN in magnetometer normalisation)
-	if((mx == 0.0f) && (my == 0.0f) && (mz == 0.0f)) {
-		MadgwickAHRSupdateIMU();
-        std::cout << "Debug1: "; 
-        std::cout << mx << "," << my << "," << mz << std::endl;
-		return;
-	}
+        // SILSIM Data Logging
+        void log_madgwick_state(double tStamp);
 
-	// Rate of change of quaternion from gyroscope
-	qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
-	qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
-	qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
-	qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
+    private:
+        pointers* pointer_struct_;
+        StateData* state_data_ptr_;
+        LowGData* lowG_data_ptr_;
 
-	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
-	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) {
+        mutex_t* dataMutex_lowG_;
+        mutex_t* dataMutex_state_;
 
-		// Normalise accelerometer measurement
-		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
-		ax *= recipNorm;
-		ay *= recipNorm;
-		az *= recipNorm;   
+        float beta_ = betaDef;
+        float q0 = 1.0, q1 = 0.0, q2 = 0.0, q3 = 0.0;
 
-		// Normalise magnetometer measurement
-		recipNorm = invSqrt(mx * mx + my * my + mz * mz);
-		mx *= recipNorm;
-		my *= recipNorm;
-		mz *= recipNorm;
+        float invSqrt(float x);
 
-		// Auxiliary variables to avoid repeated arithmetic
-		_2q0mx = 2.0f * q0 * mx;
-		_2q0my = 2.0f * q0 * my;
-		_2q0mz = 2.0f * q0 * mz;
-		_2q1mx = 2.0f * q1 * mx;
-		_2q0 = 2.0f * q0;
-		_2q1 = 2.0f * q1;
-		_2q2 = 2.0f * q2;
-		_2q3 = 2.0f * q3;
-		_2q0q2 = 2.0f * q0 * q2;
-		_2q2q3 = 2.0f * q2 * q3;
-		q0q0 = q0 * q0;
-		q0q1 = q0 * q1;
-		q0q2 = q0 * q2;
-		q0q3 = q0 * q3;
-		q1q1 = q1 * q1;
-		q1q2 = q1 * q2;
-		q1q3 = q1 * q3;
-		q2q2 = q2 * q2;
-		q2q3 = q2 * q3;
-		q3q3 = q3 * q3;
+        // SILSIM Data Logging
+        std::shared_ptr<spdlog::logger> madgwick_logger_;
+        std::string datalog_format_string = 
+            "timestamp,q0,q1,q2,q3";
+};
 
-		// Reference direction of Earth's magnetic field
-		hx = mx * q0q0 - _2q0my * q3 + _2q0mz * q2 + mx * q1q1 + _2q1 * my * q2 + _2q1 * mz * q3 - mx * q2q2 - mx * q3q3;
-		hy = _2q0mx * q3 + my * q0q0 - _2q0mz * q1 + _2q1mx * q2 - my * q1q1 + my * q2q2 + _2q2 * mz * q3 - my * q3q3;
-		_2bx = sqrt(hx * hx + hy * hy);
-		_2bz = -_2q0mx * q2 + _2q0my * q1 + mz * q0q0 + _2q1mx * q3 - mz * q1q1 + _2q2 * my * q3 - mz * q2q2 + mz * q3q3;
-		_4bx = 2.0f * _2bx;
-		_4bz = 2.0f * _2bz;
-
-		// Gradient decent algorithm corrective step
-		s0 = -_2q2 * (2.0f * q1q3 - _2q0q2 - ax) + _2q1 * (2.0f * q0q1 + _2q2q3 - ay) - _2bz * q2 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q3 + _2bz * q1) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q2 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-		s1 = _2q3 * (2.0f * q1q3 - _2q0q2 - ax) + _2q0 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q1 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + _2bz * q3 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q2 + _2bz * q0) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q3 - _4bz * q1) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-		s2 = -_2q0 * (2.0f * q1q3 - _2q0q2 - ax) + _2q3 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q2 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + (-_4bx * q2 - _2bz * q0) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q1 + _2bz * q3) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q0 - _4bz * q2) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-		s3 = _2q1 * (2.0f * q1q3 - _2q0q2 - ax) + _2q2 * (2.0f * q0q1 + _2q2q3 - ay) + (-_4bx * q3 + _2bz * q1) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q0 + _2bz * q2) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q1 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
-		s0 *= recipNorm;
-		s1 *= recipNorm;
-		s2 *= recipNorm;
-		s3 *= recipNorm;
-
-		// Apply feedback step
-		qDot1 -= beta_ * s0;
-		qDot2 -= beta_ * s1;
-		qDot3 -= beta_ * s2;
-		qDot4 -= beta_ * s3;
-	}
-    else {
-        std::cout << "Debug2" << std::endl;
-    }
-
-	// Integrate rate of change of quaternion to yield quaternion
-	q0 += qDot1 * (1.0f / sampleFreq);
-	q1 += qDot2 * (1.0f / sampleFreq);
-	q2 += qDot3 * (1.0f / sampleFreq);
-	q3 += qDot4 * (1.0f / sampleFreq);
-
-	// Normalise quaternion
-	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
-	q0 *= recipNorm;
-	q1 *= recipNorm;
-	q2 *= recipNorm;
-	q3 *= recipNorm;
-
-
-    // Write orientation estimate to stateData struct
-    chMtxLock(dataMutex_state_);
-    state_data_ptr_->state_q0 = q0;
-    state_data_ptr_->state_q1 = q1;
-    state_data_ptr_->state_q2 = q2;
-    state_data_ptr_->state_q3 = q3;
-    chMtxUnlock(dataMutex_state_);
-}
-
-
-void MadgwickAHRS::MadgwickAHRSupdateIMU() {
-
-    // Fetch data from sensors
-    chMtxLock(dataMutex_lowG_);
-    float gx = lowG_data_ptr_->gx;
-    float gy = lowG_data_ptr_->gy;
-    float gz = lowG_data_ptr_->gz;
-
-    float ax = lowG_data_ptr_->ax;
-    float ay = lowG_data_ptr_->ay;
-    float az = lowG_data_ptr_->az;
-
-    float mx = lowG_data_ptr_->mx;
-    float my = lowG_data_ptr_->my;
-    float mz = lowG_data_ptr_->mz;
-    chMtxUnlock(dataMutex_lowG_);
-
-	float recipNorm;
-	float s0, s1, s2, s3;
-	float qDot1, qDot2, qDot3, qDot4;
-	float _2q0, _2q1, _2q2, _2q3, _4q0, _4q1, _4q2 ,_8q1, _8q2, q0q0, q1q1, q2q2, q3q3;
-
-	// Rate of change of quaternion from gyroscope
-	qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
-	qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
-	qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
-	qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
-
-	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
-	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) {
-
-		// Normalise accelerometer measurement
-		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
-		ax *= recipNorm;
-		ay *= recipNorm;
-		az *= recipNorm;   
-
-		// Auxiliary variables to avoid repeated arithmetic
-		_2q0 = 2.0f * q0;
-		_2q1 = 2.0f * q1;
-		_2q2 = 2.0f * q2;
-		_2q3 = 2.0f * q3;
-		_4q0 = 4.0f * q0;
-		_4q1 = 4.0f * q1;
-		_4q2 = 4.0f * q2;
-		_8q1 = 8.0f * q1;
-		_8q2 = 8.0f * q2;
-		q0q0 = q0 * q0;
-		q1q1 = q1 * q1;
-		q2q2 = q2 * q2;
-		q3q3 = q3 * q3;
-
-		// Gradient decent algorithm corrective step
-		s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
-		s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1 - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
-		s2 = 4.0f * q0q0 * q2 + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
-		s3 = 4.0f * q1q1 * q3 - _2q1 * ax + 4.0f * q2q2 * q3 - _2q2 * ay;
-		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
-		s0 *= recipNorm;
-		s1 *= recipNorm;
-		s2 *= recipNorm;
-		s3 *= recipNorm;
-
-		// Apply feedback step
-		qDot1 -= beta_ * s0;
-		qDot2 -= beta_ * s1;
-		qDot3 -= beta_ * s2;
-		qDot4 -= beta_ * s3;
-	}
-
-	// Integrate rate of change of quaternion to yield quaternion
-	q0 += qDot1 * (1.0f / sampleFreq);
-	q1 += qDot2 * (1.0f / sampleFreq);
-	q2 += qDot3 * (1.0f / sampleFreq);
-	q3 += qDot4 * (1.0f / sampleFreq);
-
-	// Normalise quaternion
-	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
-	q0 *= recipNorm;
-	q1 *= recipNorm;
-	q2 *= recipNorm;
-	q3 *= recipNorm;
-
-
-    // Write orientation estimate to stateData struct
-    chMtxLock(dataMutex_state_);
-    state_data_ptr_->state_q0 = q0;
-    state_data_ptr_->state_q1 = q1;
-    state_data_ptr_->state_q2 = q2;
-    state_data_ptr_->state_q3 = q3;
-    chMtxUnlock(dataMutex_state_);
-}
-
-
-// Fast inverse square-root
-// See: http://en.wikipedia.org/wiki/Fast_inverse_square_root
-
-float MadgwickAHRS::invSqrt(float x) {
-	float halfx = 0.5f * x;
-	float y = x;
-	long i = *(long*)&y;
-	i = 0x5f3759df - (i>>1);
-	y = *(float*)&i;
-	y = y * (1.5f - (halfx * y * y));
-	return y;
-}
-
-// SILSIM Data Logging
-void MadgwickAHRS::log_madgwick_state(double tStamp) {
-    if (madgwick_logger_) {
-
-        std::stringstream datalog_ss;
-
-        datalog_ss << "DATA,"
-                   << tStamp << ","
-                   << q0 << ","
-                   << q1 << ","
-                   << q2 << ","
-                   << q3; 
-
-        madgwick_logger_->info(datalog_ss.str());
-    }
-}
+#endif // MADGWICK_AHRS_H

--- a/flight_src/mcu/lib/teensyShared/sensors.cpp
+++ b/flight_src/mcu/lib/teensyShared/sensors.cpp
@@ -69,10 +69,6 @@ void lowGimuTickFunction(LSM9DS1* lsm, DataLogBuffer* data_log_buffer,
     lowG_Data->mz = lsm->calcMag(lsm->mz);
     //! Unlocking &dataMutex for low g
     
-    std::cout << "Debug lowGimuTickFunction: "; 
-    // std::cout << lsm->calcMag(lsm->mx) << "," << lsm->calcMag(lsm->my) << "," << lsm->calcMag(lsm->mz) << std::endl;
-    std::cout << lsm->mx << "," << lsm->my << "," << lsm->mz << std::endl;
-
     data_log_buffer->lowGFifo.push(*lowG_Data);
     chMtxUnlock(&data_log_buffer->dataMutex_lowG);
 

--- a/flight_src/mcu/lib/teensyShared/sensors.cpp
+++ b/flight_src/mcu/lib/teensyShared/sensors.cpp
@@ -30,6 +30,8 @@
 #include "pins.h"
 #include "sensors.h"
 
+#include <iostream>
+
 /**
  * @brief Construct a new thd function object to handle data collection from the
  * low-g IMU.
@@ -66,6 +68,10 @@ void lowGimuTickFunction(LSM9DS1* lsm, DataLogBuffer* data_log_buffer,
     lowG_Data->my = lsm->calcMag(lsm->my);
     lowG_Data->mz = lsm->calcMag(lsm->mz);
     //! Unlocking &dataMutex for low g
+    
+    std::cout << "Debug lowGimuTickFunction: "; 
+    // std::cout << lsm->calcMag(lsm->mx) << "," << lsm->calcMag(lsm->my) << "," << lsm->calcMag(lsm->mz) << std::endl;
+    std::cout << lsm->mx << "," << lsm->my << "," << lsm->mz << std::endl;
 
     data_log_buffer->lowGFifo.push(*lowG_Data);
     chMtxUnlock(&data_log_buffer->dataMutex_lowG);

--- a/flight_src/mcu/src/mcu_ac/main.cpp
+++ b/flight_src/mcu/src/mcu_ac/main.cpp
@@ -28,7 +28,6 @@
 #include "ActiveControl.h"
 #include "KX134-1211.h"  //High-G IMU Library
 #include "MS5611.h"      //Barometer library
-#include "MadgwickAHRS.cpp"
 #include "ServoControl.h"
 #include "SparkFunLSM9DS1.h"                       //Low-G IMU Library
 #include "SparkFun_u-blox_GNSS_Arduino_Library.h"  //GPS Library
@@ -195,8 +194,7 @@ class Kalman_Filter_THD : public CpuThread {
     Kalman_Filter_THD(void *arg, uint8_t prio)
         : CpuThread(prio),
           pointer_struct((struct pointers *)arg),
-          Kf((struct pointers *)arg),
-          madgwick((struct pointers *)arg) {
+          Kf((struct pointers *)arg) {
         Serial.println("Initialize Kalman");
         Kf.Initialize(0.0, 0.0, 0.0);
     }
@@ -204,10 +202,7 @@ class Kalman_Filter_THD : public CpuThread {
    double loop(double timestamp) override {
         Kf.kfTickFunction();
 
-        madgwick.MadgwickAHRSupdateIMU();
-
         Kf.log_kf_state(timestamp);
-        madgwick.log_madgwick_state(timestamp);
 
         //Serial.println("Predicted Alt:");
         // Serial.println(std::to_string(Kf.x_k(0, 0)).c_str());
@@ -225,7 +220,6 @@ class Kalman_Filter_THD : public CpuThread {
 
    private:
     KalmanFilter Kf;
-    MadgwickAHRS madgwick;
     struct pointers *pointer_struct;
 };
 

--- a/flight_src/mcu/src/mcu_ac/main.cpp
+++ b/flight_src/mcu/src/mcu_ac/main.cpp
@@ -28,6 +28,7 @@
 #include "ActiveControl.h"
 #include "KX134-1211.h"  //High-G IMU Library
 #include "MS5611.h"      //Barometer library
+#include "MadgwickAHRS.cpp"
 #include "ServoControl.h"
 #include "SparkFunLSM9DS1.h"                       //Low-G IMU Library
 #include "SparkFun_u-blox_GNSS_Arduino_Library.h"  //GPS Library
@@ -38,6 +39,7 @@
 #include "rocketFSM.h"
 #include "sensors.h"
 #include "kalmanFilter.h"
+#include "MadgwickAHRS.h"
 
 // emulation for global variables
 #include <CpuThread.h>
@@ -193,7 +195,8 @@ class Kalman_Filter_THD : public CpuThread {
     Kalman_Filter_THD(void *arg, uint8_t prio)
         : CpuThread(prio),
           pointer_struct((struct pointers *)arg),
-          Kf((struct pointers *)arg) {
+          Kf((struct pointers *)arg),
+          madgwick((struct pointers *)arg) {
         Serial.println("Initialize Kalman");
         Kf.Initialize(0.0, 0.0, 0.0);
     }
@@ -201,7 +204,11 @@ class Kalman_Filter_THD : public CpuThread {
    double loop(double timestamp) override {
         Kf.kfTickFunction();
 
+        madgwick.MadgwickAHRSupdate();
+
         Kf.log_kf_state(timestamp);
+        madgwick.log_madgwick_state(timestamp);
+
         //Serial.println("Predicted Alt:");
         // Serial.println(std::to_string(Kf.x_k(0, 0)).c_str());
         // Serial.println("Predicted Vel:");
@@ -218,6 +225,7 @@ class Kalman_Filter_THD : public CpuThread {
 
    private:
     KalmanFilter Kf;
+    MadgwickAHRS madgwick;
     struct pointers *pointer_struct;
 };
 

--- a/flight_src/mcu/src/mcu_ac/main.cpp
+++ b/flight_src/mcu/src/mcu_ac/main.cpp
@@ -74,7 +74,7 @@ class rocket_FSM : public CpuThread {
 #endif
         stateMachine.tickFSM();
         stateMachine.log_FSM_state(timestamp);
-        return 6.0;  // FSM runs at 100 Hz
+        return 10.0;  // FSM runs at 100 Hz
     }
 
    private:
@@ -204,7 +204,7 @@ class Kalman_Filter_THD : public CpuThread {
    double loop(double timestamp) override {
         Kf.kfTickFunction();
 
-        madgwick.MadgwickAHRSupdate();
+        madgwick.MadgwickAHRSupdateIMU();
 
         Kf.log_kf_state(timestamp);
         madgwick.log_madgwick_state(timestamp);
@@ -399,6 +399,7 @@ void emu_setup() {
     }
 
     lowGimu.setAccelScale(16);
+    lowGimu.setMagScale(16);
 
     // GPS Setup
     if (!gps.begin(SPI, ZOEM8Q0_CS, 4000000)) {

--- a/scripts/run_debug.sh
+++ b/scripts/run_debug.sh
@@ -1,0 +1,3 @@
+rm logs/silsim_datalog.log
+./scripts/build-and-run-linux.sh
+python data_processing/kalman_debug.py

--- a/src/Sensors/Sensor.cpp
+++ b/src/Sensors/Sensor.cpp
@@ -182,9 +182,18 @@ Magnetometer::Magnetometer(std::string name, Rocket& rocket,
         sensor_logger_->info("DATALOG_FORMAT," + datalog_format_string);
     }
 }
-void Magnetometer::update_data(double tStep) {}
 
-void Magnetometer::get_data(Vector3d& data) { data = {}; }
+void Magnetometer::update_data(double tStep) {
+    Vector3d north_enu = {0.0, 10000.0, 0.0};
+    Vector3d north_rf = rocket_.enu2r(north_enu);
+    data_ = north_rf;
+    new_data_ = true;
+}
+
+void Magnetometer::get_data(Vector3d& data) {
+    data = data_;
+    new_data_ = false;
+}
 
 void Magnetometer::log_sensor_state(double tStamp) {
     if (sensor_logger_) {

--- a/src/Sensors/Sensor.cpp
+++ b/src/Sensors/Sensor.cpp
@@ -184,7 +184,7 @@ Magnetometer::Magnetometer(std::string name, Rocket& rocket,
 }
 
 void Magnetometer::update_data(double tStep) {
-    Vector3d north_enu = {0.0, 10000.0, 0.0};
+    Vector3d north_enu = {0.0, 1.0, 0.0};
     Vector3d north_rf = rocket_.enu2r(north_enu);
     data_ = north_rf;
     new_data_ = true;

--- a/src/SimulationCore/Simulation.cpp
+++ b/src/SimulationCore/Simulation.cpp
@@ -74,6 +74,25 @@ void Simulation::run(int steps) {
     motor_.log_motor_state(tStamp_);
     atmoshpere_.log_atmosphere_state(tStamp_);
 
+    // Wait 15 seconds before ignition
+    while (tStamp_ < 15.0) {
+        // Update all sensors' internal state
+        update_sensors();
+
+        // Tick the emulated CPU and threads
+        cpu_.tick(tStamp_);
+
+        // Do all the data logging!
+        log_simulation_state();
+        log_simulation_debug();
+        log_sensors();
+        rocket_.log_rocket_state(tStamp_);
+        rocket_.log_control_surfaces(tStamp_);
+        motor_.log_motor_state(tStamp_);
+
+        tStamp_ += tStep_;
+    }
+
     // send it
     motor_.ignite(tStamp_);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,8 @@ int main() {
     // Contruct Sensors -------------------------------------------------------
     Accelerometer accel1("LSM9_accel", rocket, 100, silsim_datalog_sink);
     accel1.enable_noise_injection();
-    Gyroscope gyro1("LSM9_gyro", rocket, 100, silsim_datalog_sink);
+    Gyroscope gyro1("LSM9_gyro", rocket, 100, silsim_datalog_sink, 0.001, 0.01);
+    gyro1.enable_noise_injection();
     Thermometer thermo1("MS5611_thermometer", rocket, 100, silsim_datalog_sink);
     Barometer baro1("MS5611_barometer", rocket, 100, silsim_datalog_sink, 0,
                     150 / 1.645);


### PR DESCRIPTION
Implemented the Madgwick filter into the `MadgwickAHRS` class in `teensyShared`. Unfortuantely, the filter's reliance on the gravity vector as an attitude reference makes it unsuitable for use during flight.

Still merging in to `master` because the filter could be useful during startup calibration when the rocket is stationary.